### PR TITLE
refactor: design system single source of truth (issue #19)

### DIFF
--- a/app/categoria/[category]/[subcategory]/page.tsx
+++ b/app/categoria/[category]/[subcategory]/page.tsx
@@ -161,7 +161,7 @@ export default function SubcategoryPage({
             {subcategory.tags.map((tag) => (
               <button
                 key={tag}
-                className="px-2.5 py-1 cursor-pointer"
+                className="px-2.5 py-1 cursor-pointer font-mono font-bold"
                 onClick={() => {
                   setSelectedTag(selectedTag === tag ? null : tag);
                   setCurrentPage(1);
@@ -171,9 +171,7 @@ export default function SubcategoryPage({
                     selectedTag === tag ? `${category.accentColor}55` : `${category.accentColor}22`,
                   backdropFilter: "blur(8px)",
                   border: `1.5px solid ${selectedTag === tag ? category.accentColor : `${category.accentColor}55`}`,
-                  fontFamily: "'Space Mono', monospace",
                   fontSize: "9px",
-                  fontWeight: 700,
                   color: selectedTag === tag ? "#fff" : category.accentColor,
                   transition: "all 0.2s ease",
                 }}
@@ -191,22 +189,12 @@ export default function SubcategoryPage({
             }}
           >
             <Hash size={12} style={{ color: "rgba(255,255,255,0.7)" }} />
-            <span
-              style={{
-                fontFamily: "'Space Grotesk', sans-serif",
-                fontWeight: 700,
-                fontSize: "14px",
-                color: "#fff",
-              }}
-            >
+            <span className="font-grotesk font-bold text-white" style={{ fontSize: "14px" }}>
               {subcategory.postCount}
             </span>
             <span
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "9px",
-                color: "rgba(255,255,255,0.5)",
-              }}
+              className="font-mono"
+              style={{ fontSize: "9px", color: "rgba(255,255,255,0.5)" }}
             >
               posts
             </span>
@@ -219,8 +207,8 @@ export default function SubcategoryPage({
           transition={{ duration: 0.5, delay: 1.5 }}
         >
           <span
+            className="font-mono"
             style={{
-              fontFamily: "'Space Mono', monospace",
               fontSize: "8px",
               color: "rgba(255,255,255,0.5)",
               letterSpacing: "0.15em",
@@ -263,11 +251,8 @@ export default function SubcategoryPage({
                   color="#fff"
                 />
                 <span
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "9px",
-                    color: "#a0c4ff",
-                  }}
+                  className="font-mono text-chrome-blue-body"
+                  style={{ fontSize: "9px" }}
                 >
                   {filteredPosts.length} ENTRIES FOUND
                 </span>
@@ -284,34 +269,24 @@ export default function SubcategoryPage({
                   >
                     <Link
                       href="/post/a-revolucao-do-algoritmo"
-                      className="flex flex-col cursor-pointer group"
-                      style={{
-                        border: "2px solid #0560e0",
-                        backgroundColor: "#0458d4",
-                        textDecoration: "none",
-                      }}
+                      className="flex flex-col cursor-pointer group border-2 border-chrome-blue-accent bg-chrome-blue-mid"
+                      style={{ textDecoration: "none" }}
                     >
                       <div
-                        className="flex items-center justify-between px-2 py-1"
-                        style={{ backgroundColor: "#0560e0", borderBottom: "2px solid #0560e0" }}
+                        className="flex items-center justify-between px-2 py-1 bg-chrome-blue-accent border-b-2 border-chrome-blue-accent"
                       >
                         <span
-                          style={{
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "8px",
-                            color: "#a0c4ff",
-                          }}
+                          className="font-mono text-chrome-blue-body"
+                          style={{ fontSize: "8px" }}
                         >
                           POST-{String(post.id).padStart(3, "0")}.MD
                         </span>
                         <div className="flex gap-1">
                           <div
-                            className="w-2 h-2"
-                            style={{ backgroundColor: "#0347c1", border: "1px solid #022a6e" }}
+                            className="w-2 h-2 bg-chrome-blue border border-chrome-blue-dark"
                           />
                           <div
-                            className="w-2 h-2"
-                            style={{ backgroundColor: "#e05050", border: "1px solid #022a6e" }}
+                            className="w-2 h-2 bg-chrome-red border border-chrome-blue-dark"
                           />
                         </div>
                       </div>
@@ -331,14 +306,10 @@ export default function SubcategoryPage({
                           }}
                         />
                         <div
-                          className="absolute top-2 left-2 px-2 py-0.5"
+                          className="absolute top-2 left-2 px-2 py-0.5 font-mono font-bold text-chrome-blue-dark border-2 border-chrome-blue-dark"
                           style={{
                             backgroundColor: category.accentColor,
-                            border: "2px solid #022a6e",
-                            fontFamily: "'Space Mono', monospace",
                             fontSize: "8px",
-                            fontWeight: 700,
-                            color: "#022a6e",
                             boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
                           }}
                         >
@@ -354,54 +325,35 @@ export default function SubcategoryPage({
                       </div>
                       <div className="p-3 flex flex-col flex-1">
                         <h3
-                          style={{
-                            fontFamily: "'Space Grotesk', sans-serif",
-                            fontWeight: 700,
-                            fontSize: "13px",
-                            color: "#fff",
-                            lineHeight: 1.3,
-                            marginBottom: "6px",
-                          }}
+                          className="font-grotesk font-bold text-white"
+                          style={{ fontSize: "13px", lineHeight: 1.3, marginBottom: "6px" }}
                         >
                           {post.title}
                         </h3>
                         <p
-                          className="flex-1"
-                          style={{
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "10px",
-                            lineHeight: 1.5,
-                            color: "#c8e0ff",
-                            marginBottom: "8px",
-                          }}
+                          className="flex-1 font-mono text-chrome-blue-text-on-dark"
+                          style={{ fontSize: "10px", lineHeight: 1.5, marginBottom: "8px" }}
                         >
                           {post.excerpt}
                         </p>
                         <div
-                          className="flex items-center gap-3 pt-2"
-                          style={{ borderTop: "1px solid #0560e0" }}
+                          className="flex items-center gap-3 pt-2 border-t border-chrome-blue-accent"
                         >
-                          <div className="flex items-center gap-1" style={{ color: "#a0c4ff" }}>
+                          <div className="flex items-center gap-1 text-chrome-blue-body">
                             <Clock size={10} />
-                            <span
-                              style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}
-                            >
+                            <span className="font-mono" style={{ fontSize: "8px" }}>
                               {post.date}
                             </span>
                           </div>
-                          <div className="flex items-center gap-1" style={{ color: "#a0c4ff" }}>
+                          <div className="flex items-center gap-1 text-chrome-blue-body">
                             <Eye size={10} />
-                            <span
-                              style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}
-                            >
+                            <span className="font-mono" style={{ fontSize: "8px" }}>
                               {post.reads}
                             </span>
                           </div>
-                          <div className="flex items-center gap-1" style={{ color: "#a0c4ff" }}>
+                          <div className="flex items-center gap-1 text-chrome-blue-body">
                             <MessageCircle size={10} />
-                            <span
-                              style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}
-                            >
+                            <span className="font-mono" style={{ fontSize: "8px" }}>
                               {post.comments}
                             </span>
                           </div>
@@ -427,24 +379,15 @@ export default function SubcategoryPage({
               <div className="p-5">
                 <div className="flex items-center justify-between mb-4">
                   <span
-                    style={{
-                      fontFamily: "'Space Grotesk', sans-serif",
-                      fontWeight: 700,
-                      fontSize: "14px",
-                      color: "#022a6e",
-                    }}
+                    className="font-grotesk font-bold text-chrome-blue-dark"
+                    style={{ fontSize: "14px" }}
                   >
                     Mais em {category.name}
                   </span>
                   <Link
                     href={`/categoria/${category.slug}`}
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "10px",
-                      fontWeight: 700,
-                      color: "#0347c1",
-                      textDecoration: "none",
-                    }}
+                    className="font-mono font-bold text-chrome-blue"
+                    style={{ fontSize: "10px", textDecoration: "none" }}
                   >
                     VER TODAS →
                   </Link>
@@ -490,21 +433,14 @@ export default function SubcategoryPage({
                         </div>
                         <div className="p-2.5 flex items-center justify-between">
                           <span
-                            style={{
-                              fontFamily: "'Space Grotesk', sans-serif",
-                              fontWeight: 700,
-                              fontSize: "12px",
-                              color: "#022a6e",
-                            }}
+                            className="font-grotesk font-bold text-chrome-blue-dark"
+                            style={{ fontSize: "12px" }}
                           >
                             {s.name}
                           </span>
                           <span
-                            style={{
-                              fontFamily: "'Space Mono', monospace",
-                              fontSize: "8px",
-                              color: "#5a6a8e",
-                            }}
+                            className="font-mono"
+                            style={{ fontSize: "8px", color: "#5a6a8e" }}
                           >
                             {s.postCount}
                           </span>

--- a/app/categoria/[category]/page.tsx
+++ b/app/categoria/[category]/page.tsx
@@ -46,42 +46,24 @@ export default function CategoryPage({ params }: { params: Promise<{ category: s
           <>
             <div className="flex items-center gap-1.5" style={{ color: "rgba(255,255,255,0.8)" }}>
               <Hash size={13} />
-              <span
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
-                  fontSize: "14px",
-                }}
-              >
+              <span className="font-grotesk font-bold" style={{ fontSize: "14px" }}>
                 {category.subcategories.length}
               </span>
               <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
+                className="font-mono"
+                style={{ fontSize: "9px", color: "rgba(255,255,255,0.5)" }}
               >
                 subcategorias
               </span>
             </div>
             <div className="flex items-center gap-1.5" style={{ color: "rgba(255,255,255,0.8)" }}>
               <FileText size={13} />
-              <span
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
-                  fontSize: "14px",
-                }}
-              >
+              <span className="font-grotesk font-bold" style={{ fontSize: "14px" }}>
                 {totalPosts}
               </span>
               <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
+                className="font-mono"
+                style={{ fontSize: "9px", color: "rgba(255,255,255,0.5)" }}
               >
                 posts
               </span>
@@ -115,11 +97,8 @@ export default function CategoryPage({ params }: { params: Promise<{ category: s
                   color="#fff"
                 />
                 <span
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "9px",
-                    color: "#a0c4ff",
-                  }}
+                  className="font-mono text-chrome-blue-body"
+                  style={{ fontSize: "9px" }}
                 >
                   {category.subcategories.length} ENTRIES FOUND
                 </span>
@@ -135,10 +114,9 @@ export default function CategoryPage({ params }: { params: Promise<{ category: s
                   >
                     <Link
                       href={`/categoria/${category.slug}/${sub.slug}`}
-                      className="flex flex-col group"
+                      className="flex flex-col group bg-chrome-blue-mid"
                       style={{
                         border: "3px solid #0560e0",
-                        backgroundColor: "#0458d4",
                         textDecoration: "none",
                         boxShadow: "4px 4px 0 #022a6e",
                         transition: "transform 0.2s ease, box-shadow 0.2s ease",
@@ -153,27 +131,23 @@ export default function CategoryPage({ params }: { params: Promise<{ category: s
                       }}
                     >
                       <div
-                        className="flex items-center justify-between px-3 py-1.5"
-                        style={{ backgroundColor: "#0560e0", borderBottom: "2px solid #022a6e" }}
+                        className="flex items-center justify-between px-3 py-1.5 bg-chrome-blue-accent"
+                        style={{ borderBottom: "2px solid #022a6e" }}
                       >
                         <span
-                          style={{
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "9px",
-                            fontWeight: 700,
-                            color: "#c8e0ff",
-                          }}
+                          className="font-mono font-bold text-chrome-blue-text-on-dark"
+                          style={{ fontSize: "9px" }}
                         >
                           SUBCAT-{String(i + 1).padStart(2, "0")}.EXE
                         </span>
                         <div className="flex gap-1">
                           <div
-                            className="w-2.5 h-2.5"
-                            style={{ border: "1.5px solid #022a6e", backgroundColor: "#0347c1" }}
+                            className="w-2.5 h-2.5 bg-chrome-blue"
+                            style={{ border: "1.5px solid #022a6e" }}
                           />
                           <div
-                            className="w-2.5 h-2.5"
-                            style={{ backgroundColor: "#e05050", border: "1.5px solid #022a6e" }}
+                            className="w-2.5 h-2.5 bg-chrome-red"
+                            style={{ border: "1.5px solid #022a6e" }}
                           />
                         </div>
                       </div>
@@ -216,14 +190,12 @@ export default function CategoryPage({ params }: { params: Promise<{ category: s
                           }}
                         />
                         <div
-                          className="absolute top-3 right-3 px-2.5 py-1"
+                          className="absolute top-3 right-3 px-2.5 py-1 font-mono font-bold"
                           style={{
                             background: "rgba(0,0,0,0.5)",
                             backdropFilter: "blur(8px)",
                             border: `1.5px solid ${category.accentColor}`,
-                            fontFamily: "'Space Mono', monospace",
                             fontSize: "9px",
-                            fontWeight: 700,
                             color: category.accentColor,
                           }}
                         >
@@ -248,13 +220,8 @@ export default function CategoryPage({ params }: { params: Promise<{ category: s
                           />
                         </div>
                         <p
-                          className="mb-3"
-                          style={{
-                            fontFamily: "'Space Grotesk', sans-serif",
-                            fontSize: "13px",
-                            lineHeight: 1.6,
-                            color: "#c8e0ff",
-                          }}
+                          className="mb-3 font-grotesk text-chrome-blue-text-on-dark"
+                          style={{ fontSize: "13px", lineHeight: 1.6 }}
                         >
                           {sub.description.length > 130
                             ? sub.description.slice(0, 130) + "..."
@@ -264,14 +231,11 @@ export default function CategoryPage({ params }: { params: Promise<{ category: s
                           {sub.tags.map((tag) => (
                             <span
                               key={tag}
-                              className="px-2 py-0.5"
+                              className="px-2 py-0.5 font-mono font-bold text-chrome-blue-body"
                               style={{
                                 border: "1.5px solid #0560e0",
                                 backgroundColor: "rgba(5,96,224,0.3)",
-                                fontFamily: "'Space Mono', monospace",
                                 fontSize: "8px",
-                                fontWeight: 700,
-                                color: "#a0c4ff",
                               }}
                             >
                               {tag.toUpperCase()}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -186,11 +186,10 @@ export default function NotFound() {
           <div className="p-6">
             <div className="flex justify-center mb-4">
               <pre
+                className="font-mono text-chrome-red"
                 style={{
-                  fontFamily: "'Space Mono', monospace",
                   fontSize: "10px",
                   lineHeight: 1.2,
-                  color: "#e05050",
                   letterSpacing: "0.05em",
                   animation: "glitchShake 0.5s ease-in-out infinite",
                 }}
@@ -209,45 +208,36 @@ export default function NotFound() {
             </div>
 
             <div
-              className="mb-5 p-3"
-              style={{
-                backgroundColor: "#0347c1",
-                border: "3px solid #022a6e",
-                boxShadow: "3px 3px 0 #022a6e",
-              }}
+              className="mb-5 p-3 bg-chrome-blue"
+              style={{ border: "3px solid #022a6e", boxShadow: "3px 3px 0 #022a6e" }}
             >
               <div className="flex items-center gap-2 mb-2">
                 <div
-                  className="w-2.5 h-2.5"
-                  style={{ backgroundColor: "#e05050", border: "1px solid #022a6e" }}
+                  className="w-2.5 h-2.5 bg-chrome-red border border-chrome-blue-dark"
                 />
                 <div
-                  className="w-2.5 h-2.5"
-                  style={{ backgroundColor: "#4ade80", border: "1px solid #022a6e" }}
+                  className="w-2.5 h-2.5 bg-chrome-green border border-chrome-blue-dark"
                 />
                 <span
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "8px",
-                    color: "#e8f4ff",
-                  }}
+                  className="font-mono"
+                  style={{ fontSize: "8px", color: "#e8f4ff" }}
                 >
                   TERMINAL_OUTPUT.LOG
                 </span>
               </div>
               <div
+                className="font-mono"
                 style={{
-                  fontFamily: "'Space Mono', monospace",
                   fontSize: "11px",
                   color: "#e8f4ff",
                   lineHeight: 1.6,
                   minHeight: "20px",
                 }}
               >
-                <span style={{ color: "#4ade80" }}>{">"}</span> {typedText}
+                <span className="text-chrome-green">{">"}</span> {typedText}
                 <span
+                  className="text-chrome-green"
                   style={{
-                    color: "#4ade80",
                     opacity: showCursor ? 1 : 0,
                     transition: "opacity 0.1s",
                   }}
@@ -258,9 +248,8 @@ export default function NotFound() {
             </div>
 
             <p
-              className="text-center mb-5"
+              className="text-center mb-5 font-mono"
               style={{
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "11px",
                 lineHeight: 1.6,
                 color: "#5a7a9a",
@@ -281,22 +270,14 @@ export default function NotFound() {
               }}
             >
               <span
-                style={{
-                  fontFamily: "'Bungee Shade', sans-serif",
-                  fontSize: "11px",
-                  color: "#0347c1",
-                  letterSpacing: "0.05em",
-                }}
+                className="font-bungee text-chrome-blue"
+                style={{ fontSize: "11px", letterSpacing: "0.05em" }}
               >
                 ARMANDO
               </span>
               <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "#a0c4ff",
-                  marginLeft: "8px",
-                }}
+                className="font-mono text-chrome-blue-body"
+                style={{ fontSize: "9px", marginLeft: "8px" }}
               >
                 {"// arte & tecnologia digital"}
               </span>
@@ -305,13 +286,9 @@ export default function NotFound() {
             <div className="flex items-center justify-center gap-3">
               <Link
                 href="/"
-                className="px-5 py-2.5 cursor-pointer inline-flex items-center gap-2"
+                className="px-5 py-2.5 cursor-pointer inline-flex items-center gap-2 font-grotesk font-bold bg-white text-chrome-blue"
                 style={{
-                  backgroundColor: "#fff",
-                  color: "#0347c1",
                   border: "3px solid #022a6e",
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
                   fontSize: "12px",
                   boxShadow: "3px 3px 0 #022a6e",
                   textDecoration: "none",
@@ -324,13 +301,10 @@ export default function NotFound() {
               </Link>
 
               <button
-                className="px-5 py-2.5 cursor-pointer inline-flex items-center gap-2"
+                className="px-5 py-2.5 cursor-pointer inline-flex items-center gap-2 font-grotesk font-bold bg-chrome-blue-mid"
                 style={{
-                  backgroundColor: "#0458d4",
                   color: "#e8f4ff",
                   border: "3px solid #022a6e",
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
                   fontSize: "12px",
                   boxShadow: "3px 3px 0 #022a6e",
                   transition: "transform 0.2s ease, box-shadow 0.2s ease",
@@ -346,31 +320,24 @@ export default function NotFound() {
             <div className="mt-5">
               <div className="flex items-center justify-between mb-1">
                 <span
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "8px",
-                    color: "#a0c4ff",
-                  }}
+                  className="font-mono text-chrome-blue-body"
+                  style={{ fontSize: "8px" }}
                 >
                   SEARCHING_REALITY.EXE...
                 </span>
                 <span
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "8px",
-                    color: "#e05050",
-                  }}
+                  className="font-mono text-chrome-red"
+                  style={{ fontSize: "8px" }}
                 >
                   FAILED
                 </span>
               </div>
               <div
-                className="h-2.5 w-full overflow-hidden"
-                style={{ border: "2px solid #022a6e", backgroundColor: "#e8e4dc" }}
+                className="h-2.5 w-full overflow-hidden border-2 border-chrome-blue-dark"
+                style={{ backgroundColor: "#e8e4dc" }}
               >
                 <motion.div
-                  className="h-full"
-                  style={{ backgroundColor: "#e05050" }}
+                  className="h-full bg-chrome-red"
                   initial={{ width: "0%" }}
                   animate={{ width: "100%" }}
                   transition={{ duration: 2, ease: "easeInOut" }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,8 +38,8 @@ export default function HomePage() {
         <div className="flex flex-col sm:flex-row items-start gap-4 mb-6">
           <div className="flex-1 min-w-0">
             <div
+              className="font-mono"
               style={{
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "10px",
                 color: "var(--arm-blue)",
                 marginBottom: "4px",

--- a/app/playlists/page.tsx
+++ b/app/playlists/page.tsx
@@ -54,14 +54,12 @@ function GenreChip({
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-1.5 px-3 py-1.5 cursor-pointer transition-all"
+      className="flex items-center gap-1.5 px-3 py-1.5 cursor-pointer transition-all font-mono font-bold"
       style={{
         border: isActive ? `2px solid ${color}` : "2px solid #0560e0",
         backgroundColor: isActive ? `${color}22` : "#0458d4",
         color: isActive ? color : "#c8e0ff",
-        fontFamily: "'Space Mono', monospace",
         fontSize: "10px",
-        fontWeight: 700,
         boxShadow: isActive ? `2px 2px 0 ${color}55` : "none",
         transform: isActive ? "translate(-1px, -1px)" : "none",
       }}
@@ -92,10 +90,9 @@ const PlaylistCard = React.forwardRef<HTMLDivElement, { playlist: Playlist; inde
         layout
       >
         <div
-          className="flex flex-col group"
+          className="flex flex-col group bg-chrome-blue-mid"
           style={{
             border: `2px solid ${isHovered ? playlist.accentColor : "#0560e0"}`,
-            backgroundColor: "#0458d4",
             transition: "border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease",
             transform: isHovered ? "translate(-2px, -2px)" : "none",
             boxShadow: isHovered ? `5px 5px 0 ${playlist.accentColor}44` : "none",
@@ -103,38 +100,22 @@ const PlaylistCard = React.forwardRef<HTMLDivElement, { playlist: Playlist; inde
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
         >
-          <div
-            className="flex items-center justify-between px-2.5 py-1"
-            style={{ backgroundColor: "#0560e0", borderBottom: "2px solid #022a6e" }}
-          >
+          <div className="flex items-center justify-between px-2.5 py-1 bg-chrome-blue-accent border-b-2 border-chrome-blue-dark">
             <div className="flex items-center gap-2">
               <Disc3
                 size={10}
                 className={isHovered ? "animate-spin" : ""}
                 style={{ color: playlist.accentColor, animationDuration: "3s" }}
               />
-              <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "8px",
-                  fontWeight: 700,
-                  color: "#c8e0ff",
-                }}
-              >
+              <span className="font-mono font-bold text-chrome-blue-text-on-dark" style={{ fontSize: "8px" }}>
                 PLAYLIST-{playlist.id.split("-")[1]}.SPT
               </span>
             </div>
             <div className="flex items-center gap-1.5">
               {isHovered && <EqualizerBars color={playlist.accentColor} />}
               <div className="flex gap-1 ml-1">
-                <div
-                  className="w-2 h-2"
-                  style={{ backgroundColor: "#0347c1", border: "1px solid #022a6e" }}
-                />
-                <div
-                  className="w-2 h-2"
-                  style={{ backgroundColor: "#e05050", border: "1px solid #022a6e" }}
-                />
+                <div className="w-2 h-2 bg-chrome-blue border border-chrome-blue-dark" />
+                <div className="w-2 h-2 bg-chrome-red border border-chrome-blue-dark" />
               </div>
             </div>
           </div>
@@ -172,21 +153,18 @@ const PlaylistCard = React.forwardRef<HTMLDivElement, { playlist: Playlist; inde
                   boxShadow: `0 4px 20px ${playlist.accentColor}88`,
                 }}
               >
-                <Play size={22} fill="#fff" style={{ color: "#fff", marginLeft: 2 }} />
+                <Play size={22} fill="#fff" className="text-white ml-0.5" />
               </div>
             </div>
             <div className="absolute top-2 left-2 flex gap-1.5 flex-wrap">
               {playlist.genres.map((g) => (
                 <span
                   key={g}
-                  className="px-2 py-0.5"
+                  className="px-2 py-0.5 font-mono font-bold text-chrome-blue-dark"
                   style={{
                     backgroundColor: genreColors[g] || "#0347c1",
                     border: "1.5px solid #022a6e",
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "7px",
-                    fontWeight: 700,
-                    color: "#022a6e",
                   }}
                 >
                   {g.toUpperCase()}
@@ -203,12 +181,8 @@ const PlaylistCard = React.forwardRef<HTMLDivElement, { playlist: Playlist; inde
             >
               <ListMusic size={10} style={{ color: playlist.accentColor }} />
               <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  fontWeight: 700,
-                  color: playlist.accentColor,
-                }}
+                className="font-mono font-bold"
+                style={{ fontSize: "9px", color: playlist.accentColor }}
               >
                 {playlist.trackCount}
               </span>
@@ -217,48 +191,34 @@ const PlaylistCard = React.forwardRef<HTMLDivElement, { playlist: Playlist; inde
 
           <div className="p-4">
             <h3
-              style={{
-                fontFamily: "'Space Grotesk', sans-serif",
-                fontWeight: 700,
-                fontSize: "16px",
-                color: "#fff",
-                lineHeight: 1.2,
-                marginBottom: "6px",
-              }}
+              className="font-grotesk font-bold text-white mb-1.5"
+              style={{ fontSize: "16px", lineHeight: 1.2 }}
             >
               {playlist.name}
             </h3>
             <p
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "10px",
-                lineHeight: 1.5,
-                color: "#c8e0ff",
-                marginBottom: "10px",
-              }}
+              className="font-mono text-chrome-blue-text-on-dark mb-2.5"
+              style={{ fontSize: "10px", lineHeight: 1.5 }}
             >
               {playlist.description.length > 120
                 ? playlist.description.slice(0, 120) + "..."
                 : playlist.description}
             </p>
-            <div
-              className="flex items-center gap-3 py-2 mb-3"
-              style={{ borderTop: "1px solid #0560e0", borderBottom: "1px solid #0560e0" }}
-            >
-              <div className="flex items-center gap-1" style={{ color: "#a0c4ff" }}>
+            <div className="flex items-center gap-3 py-2 mb-3 border-y border-chrome-blue-accent">
+              <div className="flex items-center gap-1 text-chrome-blue-body">
                 <Clock size={10} />
-                <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}>
+                <span className="font-mono" style={{ fontSize: "8px" }}>
                   {playlist.totalDuration}
                 </span>
               </div>
-              <div className="flex items-center gap-1" style={{ color: "#a0c4ff" }}>
+              <div className="flex items-center gap-1 text-chrome-blue-body">
                 <Users size={10} />
-                <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}>
+                <span className="font-mono" style={{ fontSize: "8px" }}>
                   {playlist.followers.toLocaleString("pt-BR")}
                 </span>
               </div>
-              <div className="flex items-center gap-1 ml-auto" style={{ color: "#a0c4ff" }}>
-                <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "7px" }}>
+              <div className="flex items-center gap-1 ml-auto text-chrome-blue-body">
+                <span className="font-mono" style={{ fontSize: "7px" }}>
                   UPD: {playlist.lastUpdated}
                 </span>
               </div>
@@ -266,14 +226,11 @@ const PlaylistCard = React.forwardRef<HTMLDivElement, { playlist: Playlist; inde
 
             <button
               onClick={() => setExpanded(!expanded)}
-              className="w-full flex items-center justify-between px-2 py-1.5 mb-3 cursor-pointer"
+              className="w-full flex items-center justify-between px-2 py-1.5 mb-3 cursor-pointer font-mono font-bold text-chrome-blue-text-on-dark"
               style={{
                 backgroundColor: "rgba(5,96,224,0.4)",
                 border: "1.5px solid #0560e0",
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "9px",
-                fontWeight: 700,
-                color: "#c8e0ff",
               }}
             >
               <span>{expanded ? "OCULTAR" : "VER"} TOP TRACKS</span>
@@ -308,46 +265,22 @@ const PlaylistCard = React.forwardRef<HTMLDivElement, { playlist: Playlist; inde
                         }}
                       >
                         <span
-                          style={{
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "8px",
-                            color: playlist.accentColor,
-                            width: 14,
-                            flexShrink: 0,
-                          }}
+                          className="font-mono shrink-0"
+                          style={{ fontSize: "8px", color: playlist.accentColor, width: 14 }}
                         >
                           {String(i + 1).padStart(2, "0")}
                         </span>
                         <div className="flex-1 min-w-0">
-                          <div
-                            className="truncate"
-                            style={{
-                              fontFamily: "'Space Grotesk', sans-serif",
-                              fontSize: "11px",
-                              fontWeight: 600,
-                              color: "#fff",
-                            }}
-                          >
+                          <div className="truncate font-grotesk font-semibold text-white" style={{ fontSize: "11px" }}>
                             {track.title}
                           </div>
-                          <div
-                            className="truncate"
-                            style={{
-                              fontFamily: "'Space Mono', monospace",
-                              fontSize: "8px",
-                              color: "#a0c4ff",
-                            }}
-                          >
+                          <div className="truncate font-mono text-chrome-blue-body" style={{ fontSize: "8px" }}>
                             {track.artist}
                           </div>
                         </div>
                         <span
-                          style={{
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "8px",
-                            color: "#a0c4ff",
-                            flexShrink: 0,
-                          }}
+                          className="font-mono text-chrome-blue-body shrink-0"
+                          style={{ fontSize: "8px" }}
                         >
                           {track.duration}
                         </span>
@@ -362,15 +295,10 @@ const PlaylistCard = React.forwardRef<HTMLDivElement, { playlist: Playlist; inde
               href={playlist.spotifyUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 w-full py-2 cursor-pointer"
+              className="flex items-center justify-center gap-2 w-full py-2 cursor-pointer font-mono font-bold text-white no-underline border-2 border-chrome-blue-dark"
               style={{
                 backgroundColor: "#1DB954",
-                border: "2px solid #022a6e",
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "10px",
-                fontWeight: 700,
-                color: "#fff",
-                textDecoration: "none",
                 boxShadow: "3px 3px 0 #022a6e",
                 transition: "transform 0.2s ease, box-shadow 0.2s ease",
               }}
@@ -418,8 +346,8 @@ export default function PlaylistsPage() {
 
   return (
     <div
-      className="flex-1 relative overflow-hidden"
-      style={{ backgroundColor: "var(--arm-bg)", transition: "background-color 0.3s ease" }}
+      className="flex-1 relative overflow-hidden bg-arm-bg"
+      style={{ transition: "background-color 0.3s ease" }}
     >
       <CategoryHero
         minHeight="320px"
@@ -435,43 +363,19 @@ export default function PlaylistsPage() {
           <>
             <div className="flex items-center gap-1.5" style={{ color: "rgba(255,255,255,0.8)" }}>
               <Radio size={13} />
-              <span
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
-                  fontSize: "14px",
-                }}
-              >
+              <span className="font-grotesk font-bold" style={{ fontSize: "14px" }}>
                 {filteredPlaylists.length}
               </span>
-              <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
-              >
+              <span className="font-mono" style={{ fontSize: "9px", color: "rgba(255,255,255,0.5)" }}>
                 playlists
               </span>
             </div>
             <div className="flex items-center gap-1.5" style={{ color: "rgba(255,255,255,0.8)" }}>
               <Music size={13} />
-              <span
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
-                  fontSize: "14px",
-                }}
-              >
+              <span className="font-grotesk font-bold" style={{ fontSize: "14px" }}>
                 {totalTracks}
               </span>
-              <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
-              >
+              <span className="font-mono" style={{ fontSize: "9px", color: "rgba(255,255,255,0.5)" }}>
                 tracks
               </span>
             </div>
@@ -484,9 +388,7 @@ export default function PlaylistsPage() {
                   boxShadow: "0 0 6px #1DB954",
                 }}
               />
-              <span
-                style={{ fontFamily: "'Space Mono', monospace", fontSize: "9px", fontWeight: 700 }}
-              >
+              <span className="font-mono font-bold" style={{ fontSize: "9px" }}>
                 SPOTIFY CONNECTED
               </span>
             </div>
@@ -537,8 +439,8 @@ export default function PlaylistsPage() {
       />
 
       <div
-        className="relative"
-        style={{ backgroundColor: "var(--arm-bg)", transition: "background-color 0.3s ease" }}
+        className="relative bg-arm-bg"
+        style={{ transition: "background-color 0.3s ease" }}
       >
         <div
           className="absolute inset-0 pointer-events-none opacity-[0.03]"
@@ -555,15 +457,8 @@ export default function PlaylistsPage() {
             <div className="p-4">
               <div className="flex items-center justify-between mb-3">
                 <div className="flex items-center gap-2">
-                  <Filter size={14} style={{ color: "var(--arm-text)" }} />
-                  <span
-                    style={{
-                      fontFamily: "'Space Grotesk', sans-serif",
-                      fontWeight: 700,
-                      fontSize: "14px",
-                      color: "var(--arm-text)",
-                    }}
-                  >
+                  <Filter size={14} className="text-arm-text" />
+                  <span className="font-grotesk font-bold text-arm-text" style={{ fontSize: "14px" }}>
                     Filtrar por Genero
                   </span>
                 </div>
@@ -571,14 +466,10 @@ export default function PlaylistsPage() {
                   {selectedGenres.length > 0 && (
                     <button
                       onClick={clearFilters}
-                      className="flex items-center gap-1 px-2 py-1 cursor-pointer"
+                      className="flex items-center gap-1 px-2 py-1 cursor-pointer font-mono font-bold text-chrome-red border-2 border-chrome-red"
                       style={{
-                        border: "2px solid #e05050",
                         backgroundColor: "rgba(224,80,80,0.1)",
-                        fontFamily: "'Space Mono', monospace",
                         fontSize: "9px",
-                        fontWeight: 700,
-                        color: "#e05050",
                       }}
                     >
                       <X size={10} />
@@ -587,14 +478,10 @@ export default function PlaylistsPage() {
                   )}
                   <button
                     onClick={() => setFilterOpen(!filterOpen)}
-                    className="px-2 py-1 cursor-pointer"
+                    className="px-2 py-1 cursor-pointer font-mono font-bold text-arm-text border-2 border-chrome-blue-dark"
                     style={{
-                      border: "2px solid #022a6e",
                       backgroundColor: "rgba(3,71,193,0.1)",
-                      fontFamily: "'Space Mono', monospace",
                       fontSize: "9px",
-                      fontWeight: 700,
-                      color: "var(--arm-text)",
                     }}
                   >
                     {filterOpen ? "OCULTAR" : "MOSTRAR"}
@@ -628,13 +515,7 @@ export default function PlaylistsPage() {
                           border: "1.5px solid rgba(3,71,193,0.2)",
                         }}
                       >
-                        <span
-                          style={{
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "9px",
-                            color: "#5a6a8e",
-                          }}
-                        >
+                        <span className="font-mono text-arm-text-secondary" style={{ fontSize: "9px" }}>
                           FILTRANDO: {selectedGenres.map((g) => g.toUpperCase()).join(" + ")}
                           {" → "}
                           {filteredPlaylists.length} resultado
@@ -662,13 +543,7 @@ export default function PlaylistsPage() {
                     fontSize="clamp(16px, 2.5vw, 26px)"
                     color="#fff"
                   />
-                  <span
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "9px",
-                      color: "#a0c4ff",
-                    }}
-                  >
+                  <span className="font-mono text-chrome-blue-body" style={{ fontSize: "9px" }}>
                     {filteredPlaylists.length} ENTRIES FOUND
                   </span>
                 </div>
@@ -680,43 +555,24 @@ export default function PlaylistsPage() {
                     className="flex flex-col items-center justify-center py-16"
                   >
                     <div
-                      className="w-16 h-16 flex items-center justify-center mb-4"
-                      style={{ border: "3px solid #0560e0", backgroundColor: "#0458d4" }}
+                      className="w-16 h-16 flex items-center justify-center mb-4 bg-chrome-blue-mid"
+                      style={{ border: "3px solid #0560e0" }}
                     >
-                      <Music size={28} style={{ color: "#a0c4ff" }} />
+                      <Music size={28} className="text-chrome-blue-body" />
                     </div>
                     <p
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontWeight: 700,
-                        fontSize: "16px",
-                        color: "#c8e0ff",
-                        marginBottom: 8,
-                      }}
+                      className="font-grotesk font-bold text-chrome-blue-text-on-dark mb-2"
+                      style={{ fontSize: "16px" }}
                     >
                       Nenhuma playlist encontrada
                     </p>
-                    <p
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "10px",
-                        color: "#a0c4ff",
-                      }}
-                    >
+                    <p className="font-mono text-chrome-blue-body" style={{ fontSize: "10px" }}>
                       Tente selecionar outros generos no filtro acima
                     </p>
                     <button
                       onClick={clearFilters}
-                      className="mt-4 px-4 py-2 cursor-pointer"
-                      style={{
-                        border: "2px solid #0560e0",
-                        backgroundColor: "#0458d4",
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "11px",
-                        fontWeight: 700,
-                        color: "#c8e0ff",
-                        boxShadow: "3px 3px 0 #022a6e",
-                      }}
+                      className="mt-4 px-4 py-2 cursor-pointer font-mono font-bold text-chrome-blue-text-on-dark border-2 border-chrome-blue-accent bg-chrome-blue-mid"
+                      style={{ fontSize: "11px", boxShadow: "3px 3px 0 #022a6e" }}
                     >
                       LIMPAR FILTROS
                     </button>
@@ -748,47 +604,32 @@ export default function PlaylistsPage() {
               <div className="p-4">
                 <div className="flex items-start gap-3">
                   <div
-                    className="w-10 h-10 flex items-center justify-center flex-shrink-0"
-                    style={{
-                      backgroundColor: "#1DB954",
-                      border: "2px solid #022a6e",
-                      boxShadow: "2px 2px 0 #022a6e",
-                    }}
+                    className="w-10 h-10 flex items-center justify-center flex-shrink-0 border-2 border-chrome-blue-dark"
+                    style={{ backgroundColor: "#1DB954", boxShadow: "2px 2px 0 #022a6e" }}
                   >
-                    <Music size={18} style={{ color: "#fff" }} />
+                    <Music size={18} className="text-white" />
                   </div>
                   <div>
                     <h4
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontWeight: 700,
-                        fontSize: "14px",
-                        color: "var(--arm-text)",
-                        marginBottom: 4,
-                      }}
+                      className="font-grotesk font-bold text-arm-text mb-1"
+                      style={{ fontSize: "14px" }}
                     >
                       Integracao com Spotify
                     </h4>
                     <p
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "10px",
-                        lineHeight: 1.6,
-                        color: "var(--arm-text-secondary)",
-                      }}
+                      className="font-mono text-arm-text-secondary"
+                      style={{ fontSize: "10px", lineHeight: 1.6 }}
                     >
                       Estas playlists serao sincronizadas automaticamente com a API do Spotify. Por
                       enquanto, os dados sao mock — a integracao real conectara ao seu perfil e
                       atualizara covers, tracklists e contagem de seguidores em tempo real.
                     </p>
                     <div
-                      className="inline-flex items-center gap-1.5 mt-2 px-2 py-1"
+                      className="inline-flex items-center gap-1.5 mt-2 px-2 py-1 font-mono font-bold"
                       style={{
                         backgroundColor: "rgba(29,185,84,0.1)",
                         border: "1.5px solid rgba(29,185,84,0.3)",
-                        fontFamily: "'Space Mono', monospace",
                         fontSize: "8px",
-                        fontWeight: 700,
                         color: "#1DB954",
                       }}
                     >

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -105,19 +105,14 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
                   <div key={section.id} id={section.id} className="mb-8">
                     <div className="flex items-center gap-3 mb-4">
                       <span
-                        style={{
-                          fontFamily: "'Space Mono', monospace",
-                          fontSize: "11px",
-                          fontWeight: 700,
-                          color: "#4ade80",
-                          minWidth: "28px",
-                        }}
+                        className="font-mono font-bold text-chrome-green"
+                        style={{ fontSize: "11px", minWidth: "28px" }}
                       >
                         {String(idx + 1).padStart(2, "0")}
                       </span>
                       <div
-                        className="flex-1"
-                        style={{ height: "2px", backgroundColor: "#0560e0" }}
+                        className="flex-1 bg-chrome-blue-accent"
+                        style={{ height: "2px" }}
                       />
                     </div>
                     <WavyText
@@ -132,12 +127,10 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
                       {section.content.split("\n\n").map((paragraph, pIdx) => (
                         <p
                           key={pIdx}
-                          className="mb-4"
+                          className="mb-4 font-grotesk text-chrome-blue-content"
                           style={{
-                            fontFamily: "'Space Grotesk', sans-serif",
                             fontSize: "15px",
                             lineHeight: 1.85,
-                            color: "#c0d8ff",
                             letterSpacing: "0.01em",
                           }}
                         >
@@ -148,17 +141,16 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
 
                     {idx < currentPost.sections.length - 1 && (
                       <div className="flex items-center gap-2 mt-6 opacity-30">
-                        <div style={{ flex: 1, height: "1px", backgroundColor: "#0560e0" }} />
+                        <div className="flex-1 bg-chrome-blue-accent" style={{ height: "1px" }} />
                         <div className="flex gap-1">
                           {[0, 1, 2].map((d) => (
                             <div
                               key={d}
-                              className="w-1.5 h-1.5"
-                              style={{ backgroundColor: "#80b0ff" }}
+                              className="w-1.5 h-1.5 bg-chrome-blue-soft"
                             />
                           ))}
                         </div>
-                        <div style={{ flex: 1, height: "1px", backgroundColor: "#0560e0" }} />
+                        <div className="flex-1 bg-chrome-blue-accent" style={{ height: "1px" }} />
                       </div>
                     )}
                   </div>

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -53,42 +53,24 @@ export default function PostsPage() {
           <>
             <div className="flex items-center gap-1.5" style={{ color: "rgba(255,255,255,0.8)" }}>
               <FileText size={13} />
-              <span
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
-                  fontSize: "14px",
-                }}
-              >
+              <span className="font-grotesk font-bold" style={{ fontSize: "14px" }}>
                 {posts.length}
               </span>
               <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
+                className="font-mono"
+                style={{ fontSize: "9px", color: "rgba(255,255,255,0.5)" }}
               >
                 posts
               </span>
             </div>
             <div className="flex items-center gap-1.5" style={{ color: "rgba(255,255,255,0.8)" }}>
               <Filter size={13} />
-              <span
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
-                  fontSize: "14px",
-                }}
-              >
+              <span className="font-grotesk font-bold" style={{ fontSize: "14px" }}>
                 {allCategories.length}
               </span>
               <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
+                className="font-mono"
+                style={{ fontSize: "9px", color: "rgba(255,255,255,0.5)" }}
               >
                 categorias
               </span>
@@ -124,24 +106,19 @@ export default function PostsPage() {
                     color="#fff"
                   />
                   <span
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "9px",
-                      color: "#a0c4ff",
-                    }}
+                    className="font-mono text-chrome-blue-body"
+                    style={{ fontSize: "9px" }}
                   >
                     {filteredPosts.length} ENTRIES FOUND
                   </span>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <button
-                    className="px-3 py-1 cursor-pointer transition-all duration-150"
+                    className="px-3 py-1 cursor-pointer transition-all duration-150 font-mono font-bold"
                     style={{
                       border: "2px solid #0560e0",
                       backgroundColor: !selectedCategory ? "#80b0ff" : "#0458d4",
-                      fontFamily: "'Space Mono', monospace",
                       fontSize: "10px",
-                      fontWeight: 700,
                       color: !selectedCategory ? "#022a6e" : "#a0c4ff",
                     }}
                     onClick={() => handleCategoryChange(null)}
@@ -151,13 +128,11 @@ export default function PostsPage() {
                   {allCategories.map((cat) => (
                     <button
                       key={cat}
-                      className="px-3 py-1 cursor-pointer transition-all duration-150"
+                      className="px-3 py-1 cursor-pointer transition-all duration-150 font-mono font-bold"
                       style={{
                         border: `2px solid ${selectedCategory === cat ? categoryColors[cat] : "#0560e0"}`,
                         backgroundColor: selectedCategory === cat ? categoryColors[cat] : "#0458d4",
-                        fontFamily: "'Space Mono', monospace",
                         fontSize: "10px",
-                        fontWeight: 700,
                         color: selectedCategory === cat ? "#022a6e" : "#a0c4ff",
                       }}
                       onClick={() => handleCategoryChange(cat)}
@@ -212,8 +187,8 @@ export default function PostsPage() {
                         }}
                       >
                         <span
+                          className="font-mono"
                           style={{
-                            fontFamily: "'Space Mono', monospace",
                             fontSize: "8px",
                             color: post.isCorrupted ? "#ff4444" : "#a0c4ff",
                           }}
@@ -224,12 +199,10 @@ export default function PostsPage() {
                         </span>
                         <div className="flex gap-1">
                           <div
-                            className="w-2 h-2"
-                            style={{ backgroundColor: "#0347c1", border: "1px solid #022a6e" }}
+                            className="w-2 h-2 bg-chrome-blue border border-chrome-blue-dark"
                           />
                           <div
-                            className="w-2 h-2"
-                            style={{ backgroundColor: "#e05050", border: "1px solid #022a6e" }}
+                            className="w-2 h-2 bg-chrome-red border border-chrome-blue-dark"
                           />
                         </div>
                       </div>
@@ -251,14 +224,10 @@ export default function PostsPage() {
                           }}
                         />
                         <div
-                          className="absolute top-2 left-2 px-2 py-0.5"
+                          className="absolute top-2 left-2 px-2 py-0.5 font-mono font-bold text-chrome-blue-dark border-2 border-chrome-blue-dark"
                           style={{
                             backgroundColor: categoryColors[post.category] || "#0347c1",
-                            border: "2px solid #022a6e",
-                            fontFamily: "'Space Mono', monospace",
                             fontSize: "8px",
-                            fontWeight: 700,
-                            color: "#022a6e",
                             boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
                           }}
                         >
@@ -275,55 +244,35 @@ export default function PostsPage() {
 
                       <div className="p-3 flex flex-col flex-1 overflow-hidden">
                         <h3
-                          className="line-clamp-2"
-                          style={{
-                            fontFamily: "'Space Grotesk', sans-serif",
-                            fontWeight: 700,
-                            fontSize: "13px",
-                            color: "#fff",
-                            lineHeight: 1.3,
-                            marginBottom: "6px",
-                          }}
+                          className="line-clamp-2 font-grotesk font-bold text-white"
+                          style={{ fontSize: "13px", lineHeight: 1.3, marginBottom: "6px" }}
                         >
                           {post.title}
                         </h3>
                         <p
-                          className="flex-1 line-clamp-3"
-                          style={{
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "10px",
-                            lineHeight: 1.5,
-                            color: "#c8e0ff",
-                            marginBottom: "8px",
-                          }}
+                          className="flex-1 line-clamp-3 font-mono text-chrome-blue-text-on-dark"
+                          style={{ fontSize: "10px", lineHeight: 1.5, marginBottom: "8px" }}
                         >
                           {post.excerpt}
                         </p>
                         <div
-                          className="flex items-center gap-3 pt-2"
-                          style={{ borderTop: "1px solid #0560e0" }}
+                          className="flex items-center gap-3 pt-2 border-t border-chrome-blue-accent"
                         >
-                          <div className="flex items-center gap-1" style={{ color: "#a0c4ff" }}>
+                          <div className="flex items-center gap-1 text-chrome-blue-body">
                             <Clock size={10} />
-                            <span
-                              style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}
-                            >
+                            <span className="font-mono" style={{ fontSize: "8px" }}>
                               {post.date}
                             </span>
                           </div>
-                          <div className="flex items-center gap-1" style={{ color: "#a0c4ff" }}>
+                          <div className="flex items-center gap-1 text-chrome-blue-body">
                             <Eye size={10} />
-                            <span
-                              style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}
-                            >
+                            <span className="font-mono" style={{ fontSize: "8px" }}>
                               {post.reads}
                             </span>
                           </div>
-                          <div className="flex items-center gap-1" style={{ color: "#a0c4ff" }}>
+                          <div className="flex items-center gap-1 text-chrome-blue-body">
                             <MessageCircle size={10} />
-                            <span
-                              style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}
-                            >
+                            <span className="font-mono" style={{ fontSize: "8px" }}>
                               {post.comments}
                             </span>
                           </div>

--- a/app/sobre/page.tsx
+++ b/app/sobre/page.tsx
@@ -151,10 +151,9 @@ function StatCard({
       viewport={{ once: true }}
       transition={{ duration: 0.4, delay }}
       whileHover={{ y: -3, boxShadow: `6px 6px 0 #022a6e, 0 0 16px ${color}30` }}
-      className="flex flex-col items-center justify-center p-4 cursor-default"
+      className="flex flex-col items-center justify-center p-4 cursor-default bg-chrome-blue-mid"
       style={{
         border: "3px solid #022a6e",
-        backgroundColor: "#0458d4",
         boxShadow: "4px 4px 0 #022a6e",
         minWidth: 0,
         transition: "background-color 0.2s ease",
@@ -166,26 +165,12 @@ function StatCard({
       >
         <Icon size={20} style={{ color, marginBottom: "6px" }} />
       </motion.div>
-      <span
-        style={{
-          fontFamily: "'Space Grotesk', sans-serif",
-          fontWeight: 700,
-          fontSize: "26px",
-          color: "#fff",
-          lineHeight: 1,
-        }}
-      >
+      <span className="font-grotesk font-bold text-white" style={{ fontSize: "26px", lineHeight: 1 }}>
         {value}
       </span>
       <span
-        style={{
-          fontFamily: "'Space Mono', monospace",
-          fontSize: "8px",
-          fontWeight: 700,
-          color: "#a0c4ff",
-          marginTop: "4px",
-          letterSpacing: "0.1em",
-        }}
+        className="font-mono font-bold text-chrome-blue-body"
+        style={{ fontSize: "8px", marginTop: "4px", letterSpacing: "0.1em" }}
       >
         {label}
       </span>
@@ -376,16 +361,12 @@ export default function SobrePage() {
           >
             <Link
               href="/"
-              className="inline-flex items-center gap-2 px-3 py-1.5 mb-6"
+              className="inline-flex items-center gap-2 px-3 py-1.5 mb-6 font-mono font-bold text-white no-underline"
               style={{
                 background: "rgba(255,255,255,0.1)",
                 backdropFilter: "blur(12px)",
                 border: "2px solid rgba(255,255,255,0.2)",
-                color: "#fff",
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "10px",
-                fontWeight: 700,
-                textDecoration: "none",
               }}
             >
               <ArrowLeft size={14} />
@@ -426,13 +407,8 @@ export default function SobrePage() {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 transition={{ duration: 0.5, delay: 0.5 }}
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "11px",
-                  color: "#c084fc",
-                  marginBottom: "6px",
-                  letterSpacing: "0.12em",
-                }}
+                className="font-mono text-chrome-purple"
+                style={{ fontSize: "11px", marginBottom: "6px", letterSpacing: "0.12em" }}
               >
                 {">"} USER/ABOUT_ME_
               </motion.div>
@@ -454,12 +430,8 @@ export default function SobrePage() {
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.5, delay: 0.7 }}
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontSize: "clamp(12px, 2vw, 16px)",
-                  color: "rgba(255,255,255,0.7)",
-                  marginTop: "4px",
-                }}
+                className="font-grotesk mt-1"
+                style={{ fontSize: "clamp(12px, 2vw, 16px)", color: "rgba(255,255,255,0.7)" }}
               >
                 {AUTHOR.role}
               </motion.p>
@@ -470,29 +442,24 @@ export default function SobrePage() {
                 transition={{ duration: 0.5, delay: 0.9 }}
               >
                 <span
-                  className="inline-flex items-center gap-1.5 px-2.5 py-1"
+                  className="inline-flex items-center gap-1.5 px-2.5 py-1 font-mono font-bold"
                   style={{
                     background: "rgba(255,255,255,0.1)",
                     backdropFilter: "blur(8px)",
                     border: "1.5px solid rgba(255,255,255,0.2)",
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "9px",
-                    fontWeight: 700,
                     color: "rgba(255,255,255,0.7)",
                   }}
                 >
                   <MapPin size={11} /> {AUTHOR.location}
                 </span>
                 <span
-                  className="inline-flex items-center gap-1.5 px-2.5 py-1"
+                  className="inline-flex items-center gap-1.5 px-2.5 py-1 font-mono font-bold text-chrome-purple"
                   style={{
                     background: "rgba(192,132,252,0.15)",
                     backdropFilter: "blur(8px)",
                     border: "1.5px solid rgba(192,132,252,0.35)",
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "9px",
-                    fontWeight: 700,
-                    color: "#c084fc",
                   }}
                 >
                   <Calendar size={11} /> DESDE {AUTHOR.since}
@@ -508,13 +475,8 @@ export default function SobrePage() {
             transition={{ duration: 0.5, delay: 1.5 }}
           >
             <span
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "8px",
-                color: "rgba(255,255,255,0.5)",
-                letterSpacing: "0.15em",
-                marginBottom: "4px",
-              }}
+              className="font-mono"
+              style={{ fontSize: "8px", color: "rgba(255,255,255,0.5)", letterSpacing: "0.15em", marginBottom: "4px" }}
             >
               CONHEÇA MINHA HISTÓRIA
             </span>
@@ -554,12 +516,8 @@ export default function SobrePage() {
                       whileInView={{ opacity: 1, y: 0 }}
                       viewport={{ once: true }}
                       transition={{ duration: 0.4, delay: 0.1 * i }}
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontSize: "14px",
-                        lineHeight: 1.75,
-                        color: "#c8e0ff",
-                      }}
+                      className="font-grotesk text-chrome-blue-text-on-dark"
+                      style={{ fontSize: "14px", lineHeight: 1.75 }}
                     >
                       {p}
                     </motion.p>
@@ -574,13 +532,8 @@ export default function SobrePage() {
                   style={{ borderLeft: "4px solid #c084fc", background: "rgba(192,132,252,0.08)" }}
                 >
                   <p
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "12px",
-                      lineHeight: 1.7,
-                      color: "#c084fc",
-                      fontStyle: "italic",
-                    }}
+                    className="font-mono text-chrome-purple"
+                    style={{ fontSize: "12px", lineHeight: 1.7, fontStyle: "italic" }}
                   >
                     {AUTHOR.manifesto}
                   </p>
@@ -599,11 +552,9 @@ export default function SobrePage() {
                       whileInView={{ opacity: 1, y: 0 }}
                       viewport={{ once: true }}
                       transition={{ duration: 0.3, delay: 0.1 * i }}
-                      className="flex items-center gap-1.5 px-3 py-1.5 group"
+                      className="flex items-center gap-1.5 px-3 py-1.5 group border-2 border-chrome-blue-accent no-underline"
                       style={{
-                        border: "2px solid #0560e0",
                         backgroundColor: "rgba(5,96,224,0.3)",
-                        textDecoration: "none",
                         transition: "background-color 0.2s ease",
                       }}
                       onMouseEnter={(e) => {
@@ -614,15 +565,8 @@ export default function SobrePage() {
                           "rgba(5,96,224,0.3)";
                       }}
                     >
-                      <s.icon size={13} style={{ color: "#c8e0ff" }} />
-                      <span
-                        style={{
-                          fontFamily: "'Space Mono', monospace",
-                          fontSize: "8px",
-                          fontWeight: 700,
-                          color: "#c8e0ff",
-                        }}
-                      >
+                      <s.icon size={13} className="text-chrome-blue-text-on-dark" />
+                      <span className="font-mono font-bold text-chrome-blue-text-on-dark" style={{ fontSize: "8px" }}>
                         {s.label}
                       </span>
                     </motion.a>
@@ -634,68 +578,31 @@ export default function SobrePage() {
             <div className="space-y-5">
               <RetroWindow title="STATS.EXE" variant="dark">
                 <div className="p-4 grid grid-cols-2 gap-3">
-                  <StatCard
-                    icon={FileText}
-                    label="POSTS"
-                    value={AUTHOR.stats.posts}
-                    color="#f59e0b"
-                    delay={0}
-                  />
-                  <StatCard
-                    icon={Eye}
-                    label="VIEWS"
-                    value={AUTHOR.stats.views}
-                    color="#c8e0ff"
-                    delay={0.1}
-                  />
-                  <StatCard
-                    icon={MessageCircle}
-                    label="COMENTÁRIOS"
-                    value={AUTHOR.stats.comments}
-                    color="#4ade80"
-                    delay={0.2}
-                  />
-                  <StatCard
-                    icon={Palette}
-                    label="CATEGORIAS"
-                    value={AUTHOR.stats.categories}
-                    color="#c084fc"
-                    delay={0.3}
-                  />
+                  <StatCard icon={FileText} label="POSTS" value={AUTHOR.stats.posts} color="#f59e0b" delay={0} />
+                  <StatCard icon={Eye} label="VIEWS" value={AUTHOR.stats.views} color="#c8e0ff" delay={0.1} />
+                  <StatCard icon={MessageCircle} label="COMENTÁRIOS" value={AUTHOR.stats.comments} color="#4ade80" delay={0.2} />
+                  <StatCard icon={Palette} label="CATEGORIAS" value={AUTHOR.stats.categories} color="#c084fc" delay={0.3} />
                 </div>
               </RetroWindow>
               <RetroWindow title="NOW-PLAYING.EXE" variant="glass">
                 <div className="p-4">
                   <div className="flex items-center gap-3">
                     <div
-                      className="w-12 h-12 flex items-center justify-center"
-                      style={{ border: "2px solid #022a6e", backgroundColor: "rgba(3,71,193,0.2)" }}
+                      className="w-12 h-12 flex items-center justify-center border-2 border-chrome-blue-dark"
+                      style={{ backgroundColor: "rgba(3,71,193,0.2)" }}
                     >
                       <motion.div
                         animate={{ rotate: 360 }}
                         transition={{ duration: 3, repeat: Infinity, ease: "linear" }}
                       >
-                        <Headphones size={20} style={{ color: "#0347c1" }} />
+                        <Headphones size={20} className="text-chrome-blue" />
                       </motion.div>
                     </div>
                     <div>
-                      <p
-                        style={{
-                          fontFamily: "'Space Grotesk', sans-serif",
-                          fontWeight: 700,
-                          fontSize: "13px",
-                          color: "var(--arm-text)",
-                        }}
-                      >
+                      <p className="font-grotesk font-bold text-arm-text" style={{ fontSize: "13px" }}>
                         Midnight City
                       </p>
-                      <p
-                        style={{
-                          fontFamily: "'Space Mono', monospace",
-                          fontSize: "9px",
-                          color: "var(--arm-text-secondary)",
-                        }}
-                      >
+                      <p className="font-mono text-arm-text-secondary" style={{ fontSize: "9px" }}>
                         M83 · Hurry Up, We&apos;re Dreaming
                       </p>
                     </div>
@@ -736,25 +643,12 @@ export default function SobrePage() {
               <div className="p-5">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-2">
-                    <TrendingUp size={16} style={{ color: "#4ade80" }} />
-                    <span
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontWeight: 700,
-                        fontSize: "14px",
-                        color: "#fff",
-                      }}
-                    >
+                    <TrendingUp size={16} className="text-chrome-green" />
+                    <span className="font-grotesk font-bold text-white" style={{ fontSize: "14px" }}>
                       Atividade de Posts
                     </span>
                   </div>
-                  <span
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "9px",
-                      color: "#a0c4ff",
-                    }}
-                  >
+                  <span className="font-mono text-chrome-blue-body" style={{ fontSize: "9px" }}>
                     ÚLTIMOS 9 MESES
                   </span>
                 </div>
@@ -767,25 +661,12 @@ export default function SobrePage() {
               <div className="p-5">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-2">
-                    <Sparkles size={16} style={{ color: "#c084fc" }} />
-                    <span
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontWeight: 700,
-                        fontSize: "14px",
-                        color: "#fff",
-                      }}
-                    >
+                    <Sparkles size={16} className="text-chrome-purple" />
+                    <span className="font-grotesk font-bold text-white" style={{ fontSize: "14px" }}>
                       Áreas de Expertise
                     </span>
                   </div>
-                  <span
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "9px",
-                      color: "#a0c4ff",
-                    }}
-                  >
+                  <span className="font-mono text-chrome-blue-body" style={{ fontSize: "9px" }}>
                     PROFICIENCY %
                   </span>
                 </div>
@@ -822,12 +703,11 @@ export default function SobrePage() {
                       transition={{ duration: 0.4, delay: 0.1 * i }}
                     >
                       <div
-                        className="flex items-center justify-center flex-shrink-0 z-10"
+                        className="flex items-center justify-center flex-shrink-0 z-10 bg-chrome-blue"
                         style={{
                           width: 38,
                           height: 38,
                           border: `3px solid ${item.color}`,
-                          backgroundColor: "#0347c1",
                           boxShadow: `0 0 12px ${item.color}44`,
                         }}
                       >
@@ -839,36 +719,18 @@ export default function SobrePage() {
                       >
                         <div className="flex items-center gap-3 mb-1">
                           <span
-                            className="px-2 py-0.5"
-                            style={{
-                              backgroundColor: item.color,
-                              border: "2px solid #022a6e",
-                              fontFamily: "'Space Mono', monospace",
-                              fontSize: "10px",
-                              fontWeight: 700,
-                              color: "#022a6e",
-                            }}
+                            className="px-2 py-0.5 font-mono font-bold text-chrome-blue-dark border-2 border-chrome-blue-dark"
+                            style={{ backgroundColor: item.color, fontSize: "10px" }}
                           >
                             {item.year}
                           </span>
-                          <span
-                            style={{
-                              fontFamily: "'Space Grotesk', sans-serif",
-                              fontWeight: 700,
-                              fontSize: "15px",
-                              color: "#fff",
-                            }}
-                          >
+                          <span className="font-grotesk font-bold text-white" style={{ fontSize: "15px" }}>
                             {item.title}
                           </span>
                         </div>
                         <p
-                          style={{
-                            fontFamily: "'Space Grotesk', sans-serif",
-                            fontSize: "13px",
-                            lineHeight: 1.65,
-                            color: "#c8e0ff",
-                          }}
+                          className="font-grotesk text-chrome-blue-text-on-dark"
+                          style={{ fontSize: "13px", lineHeight: 1.65 }}
                         >
                           {item.description}
                         </p>
@@ -884,23 +746,10 @@ export default function SobrePage() {
           <RetroWindow title="INTERESTS.JSON" variant="glass">
             <div className="p-5">
               <div className="flex items-center justify-between mb-4">
-                <span
-                  style={{
-                    fontFamily: "'Space Grotesk', sans-serif",
-                    fontWeight: 700,
-                    fontSize: "14px",
-                    color: "var(--arm-text)",
-                  }}
-                >
+                <span className="font-grotesk font-bold text-arm-text" style={{ fontSize: "14px" }}>
                   Coisas que me movem
                 </span>
-                <span
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "9px",
-                    color: "var(--arm-text-secondary)",
-                  }}
-                >
+                <span className="font-mono text-arm-text-secondary" style={{ fontSize: "9px" }}>
                   {interests.length} ITEMS
                 </span>
               </div>
@@ -937,14 +786,7 @@ export default function SobrePage() {
                     >
                       <item.icon size={16} style={{ color: item.color }} />
                     </div>
-                    <span
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontWeight: 700,
-                        fontSize: "12px",
-                        color: "var(--arm-text)",
-                      }}
-                    >
+                    <span className="font-grotesk font-bold text-arm-text" style={{ fontSize: "12px" }}>
                       {item.label}
                     </span>
                   </motion.div>
@@ -957,14 +799,7 @@ export default function SobrePage() {
           <RetroWindow title="GALLERY.EXE" variant="dark">
             <div className="p-5">
               <WavyText text="FRAGMENTOS VISUAIS" variant="stacked" fontSize={24} color="#fff" />
-              <p
-                className="mt-1 mb-4"
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "10px",
-                  color: "#a0c4ff",
-                }}
-              >
+              <p className="font-mono text-chrome-blue-body mt-1 mb-4" style={{ fontSize: "10px" }}>
                 SNAPSHOTS DO MEU UNIVERSO CRIATIVO
               </p>
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
@@ -975,8 +810,8 @@ export default function SobrePage() {
                     whileInView={{ opacity: 1, scale: 1 }}
                     viewport={{ once: true }}
                     transition={{ duration: 0.4, delay: 0.1 * i }}
-                    className="group relative overflow-hidden"
-                    style={{ border: "2px solid #0560e0", height: "clamp(120px, 20vw, 160px)" }}
+                    className="group relative overflow-hidden border-2 border-chrome-blue-accent"
+                    style={{ height: "clamp(120px, 20vw, 160px)" }}
                   >
                     <AppImage
                       src={img.src}
@@ -999,13 +834,8 @@ export default function SobrePage() {
                       }}
                     >
                       <span
-                        style={{
-                          fontFamily: "'Space Mono', monospace",
-                          fontSize: "8px",
-                          fontWeight: 700,
-                          color: "#c8e0ff",
-                          letterSpacing: "0.1em",
-                        }}
+                        className="font-mono font-bold text-chrome-blue-text-on-dark"
+                        style={{ fontSize: "8px", letterSpacing: "0.1em" }}
                       >
                         {img.caption}
                       </span>

--- a/components/content/CommentsSection.tsx
+++ b/components/content/CommentsSection.tsx
@@ -66,13 +66,11 @@ export function CommentsSection() {
           />
           <Link
             href="/posts"
-            className="px-4 py-1.5 flex-shrink-0 cursor-pointer self-start transition-all duration-150 hover:brightness-125 hover:-translate-y-px"
+            className="px-4 py-1.5 flex-shrink-0 cursor-pointer self-start transition-all duration-150 hover:brightness-125 hover:-translate-y-px font-mono font-bold"
             style={{
               border: "2px solid var(--arm-panel-border)",
               backgroundColor: "var(--arm-panel-bg)",
-              fontFamily: "'Space Mono', monospace",
               fontSize: "11px",
-              fontWeight: 700,
               color: "var(--arm-panel-text-soft)",
               textDecoration: "none",
             }}
@@ -95,34 +93,21 @@ export function CommentsSection() {
                 />
               </svg>
               <span
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
-                  fontSize: "26px",
-                  color: "var(--arm-panel-text)",
-                }}
+                className="font-grotesk font-bold"
+                style={{ fontSize: "26px", color: "var(--arm-panel-text)" }}
               >
                 4.4 / 5.0
               </span>
             </div>
             <div
-              className="mt-3"
-              style={{
-                fontFamily: "'Space Grotesk', sans-serif",
-                fontWeight: 700,
-                fontSize: "38px",
-                lineHeight: 1,
-                color: "var(--arm-panel-text-soft)",
-              }}
+              className="mt-3 font-grotesk font-bold"
+              style={{ fontSize: "38px", lineHeight: 1, color: "var(--arm-panel-text-soft)" }}
             >
               127
             </div>
             <div
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "10px",
-                color: "var(--arm-panel-text-muted)",
-              }}
+              className="font-mono"
+              style={{ fontSize: "10px", color: "var(--arm-panel-text-muted)" }}
             >
               comentarios
               <br />
@@ -177,12 +162,8 @@ export function CommentsSection() {
                   {engagementData.map((entry) => (
                     <span
                       key={entry.day}
-                      className="flex-1 text-center"
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "8px",
-                        color: "var(--arm-panel-text-muted)",
-                      }}
+                      className="flex-1 text-center font-mono"
+                      style={{ fontSize: "8px", color: "var(--arm-panel-text-muted)" }}
                     >
                       {entry.day}
                     </span>
@@ -193,8 +174,8 @@ export function CommentsSection() {
               {/* Progress bar decoration */}
               <div className="mt-3">
                 <div
+                  className="font-mono"
                   style={{
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "8px",
                     color: "var(--arm-panel-text-muted)",
                     marginBottom: "3px",
@@ -271,13 +252,11 @@ export function CommentsSection() {
 
                   {/* Background decorative quote mark */}
                   <div
-                    className="absolute pointer-events-none select-none"
+                    className="absolute pointer-events-none select-none font-grotesk font-bold"
                     style={{
                       top: "12px",
                       right: "8px",
-                      fontFamily: "'Space Grotesk', sans-serif",
                       fontSize: "64px",
-                      fontWeight: 700,
                       lineHeight: 1,
                       color: accent,
                       opacity: 0.07,
@@ -304,8 +283,8 @@ export function CommentsSection() {
                         }}
                       />
                       <span
+                        className="font-mono"
                         style={{
-                          fontFamily: "'Space Mono', monospace",
                           fontSize: "8px",
                           color: "var(--arm-panel-text-muted)",
                           letterSpacing: "0.05em",
@@ -323,11 +302,8 @@ export function CommentsSection() {
                         }}
                       />
                       <div
-                        className="w-2 h-2"
-                        style={{
-                          backgroundColor: "#e05050",
-                          border: "1px solid var(--arm-panel-bg-deep)",
-                        }}
+                        className="w-2 h-2 bg-chrome-red"
+                        style={{ border: "1px solid var(--arm-panel-bg-deep)" }}
                       />
                     </div>
                   </div>
@@ -357,9 +333,8 @@ export function CommentsSection() {
                           </div>
                           {/* Online indicator */}
                           <div
-                            className="absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full"
+                            className="absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full bg-chrome-green"
                             style={{
-                              backgroundColor: "#4ade80",
                               border: "2px solid var(--arm-panel-bg-darker)",
                               boxShadow: "0 0 6px #4ade8060",
                             }}
@@ -376,11 +351,9 @@ export function CommentsSection() {
                           />
                           <div className="flex items-center gap-1.5" style={{ marginTop: "1px" }}>
                             <span
-                              className="px-1.5 py-0.5"
+                              className="px-1.5 py-0.5 font-mono font-bold"
                               style={{
-                                fontFamily: "'Space Mono', monospace",
                                 fontSize: "8px",
-                                fontWeight: 700,
                                 color: accent,
                                 backgroundColor: `${accent}18`,
                                 border: `1px solid ${accent}30`,
@@ -413,12 +386,8 @@ export function CommentsSection() {
                           ))}
                         </div>
                         <span
-                          style={{
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "9px",
-                            fontWeight: 700,
-                            color: accent,
-                          }}
+                          className="font-mono font-bold"
+                          style={{ fontSize: "9px", color: accent }}
                         >
                           {comment.rating}/5
                         </span>
@@ -431,10 +400,9 @@ export function CommentsSection() {
                       style={{ borderLeft: `2px solid ${accent}40` }}
                     >
                       <span
+                        className="font-mono font-bold"
                         style={{
-                          fontFamily: "'Space Mono', monospace",
                           fontSize: "14px",
-                          fontWeight: 700,
                           color: accent,
                           opacity: 0.6,
                           lineHeight: 1,
@@ -446,8 +414,8 @@ export function CommentsSection() {
                         &gt;
                       </span>
                       <p
+                        className="font-mono"
                         style={{
-                          fontFamily: "'Space Mono', monospace",
                           fontSize: "10px",
                           lineHeight: 1.7,
                           color: "var(--arm-panel-text-body)",
@@ -469,11 +437,10 @@ export function CommentsSection() {
                         {reactions.map((r, ri) => (
                           <button
                             key={ri}
-                            className="flex items-center gap-1 px-1.5 py-0.5 cursor-pointer"
+                            className="flex items-center gap-1 px-1.5 py-0.5 cursor-pointer font-mono"
                             style={{
                               backgroundColor: "transparent",
                               border: `1px solid ${accent}25`,
-                              fontFamily: "'Space Mono', monospace",
                               fontSize: "9px",
                               color: "var(--arm-panel-text-muted)",
                               transition: "all 0.15s ease",
@@ -497,8 +464,8 @@ export function CommentsSection() {
 
                       {/* Timestamp */}
                       <span
+                        className="font-mono"
                         style={{
-                          fontFamily: "'Space Mono', monospace",
                           fontSize: "8px",
                           color: "var(--arm-panel-text-dim)",
                           letterSpacing: "0.03em",

--- a/components/content/ContactCTA.tsx
+++ b/components/content/ContactCTA.tsx
@@ -43,9 +43,8 @@ export function ContactCTA({ accentColor = "#0347c1" }: ContactCTAProps) {
                 <Sparkles size={14} style={{ color: accentColor }} />
               </motion.div>
               <span
+                className="font-grotesk font-bold"
                 style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
                   fontSize: "clamp(14px, 2.5vw, 18px)",
                   color: "var(--arm-text)",
                 }}
@@ -54,12 +53,8 @@ export function ContactCTA({ accentColor = "#0347c1" }: ContactCTAProps) {
               </span>
             </div>
             <p
-              className="mt-1"
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "11px",
-                color: "var(--arm-text-secondary)",
-              }}
+              className="mt-1 font-mono"
+              style={{ fontSize: "11px", color: "var(--arm-text-secondary)" }}
             >
               Estou sempre aberto a colaboracoes, debates e cafes virtuais.
             </p>
@@ -67,15 +62,12 @@ export function ContactCTA({ accentColor = "#0347c1" }: ContactCTAProps) {
 
           <motion.a
             href="mailto:armando@exemplo.com"
-            className="flex items-center justify-center gap-2 px-5 py-3 relative z-10"
+            className="flex items-center justify-center gap-2 px-5 py-3 relative z-10 font-mono font-bold text-white"
             style={{
               border: "3px solid var(--arm-border)",
               backgroundColor: "var(--arm-blue)",
               boxShadow: "4px 4px 0 var(--arm-shadow)",
-              fontFamily: "'Space Mono', monospace",
               fontSize: "11px",
-              fontWeight: 700,
-              color: "#fff",
               textDecoration: "none",
               flexShrink: 0,
             }}

--- a/components/content/FeaturedPost.tsx
+++ b/components/content/FeaturedPost.tsx
@@ -98,13 +98,8 @@ export function FeaturedPost() {
                 strokeColor="#80b0ff"
               />
               <p
-                className="mt-2 mb-4"
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "12px",
-                  lineHeight: 1.7,
-                  color: "#c8e0ff",
-                }}
+                className="mt-2 mb-4 font-mono text-chrome-blue-content"
+                style={{ fontSize: "12px", lineHeight: 1.7 }}
               >
                 Um manifesto sobre como a arte digital transcende os limites do humano e do codigo.
                 Explorando as fronteiras entre criatividade artificial e expressao autentica na era
@@ -120,25 +115,17 @@ export function FeaturedPost() {
                 ].map((stat) => (
                   <div
                     key={stat.label}
-                    className="px-3 py-2 text-center"
-                    style={{ border: "2px solid #0560e0", backgroundColor: "#0458d4" }}
+                    className="px-3 py-2 text-center border-2 border-chrome-blue-accent bg-chrome-blue-mid"
                   >
                     <div
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontWeight: 700,
-                        fontSize: "18px",
-                        color: "#4ade80",
-                      }}
+                      className="font-grotesk font-bold text-chrome-green"
+                      style={{ fontSize: "18px" }}
                     >
                       {stat.value}
                     </div>
                     <div
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "9px",
-                        color: "#a0c4ff",
-                      }}
+                      className="font-mono text-chrome-blue-body"
+                      style={{ fontSize: "9px" }}
                     >
                       {stat.label}
                     </div>
@@ -150,13 +137,9 @@ export function FeaturedPost() {
             <div className="flex gap-3 mt-5">
               <Link
                 href="/post/a-revolucao-do-algoritmo"
-                className="px-5 py-2.5 cursor-pointer inline-block"
+                className="px-5 py-2.5 cursor-pointer inline-block font-grotesk font-bold bg-white text-chrome-blue"
                 style={{
-                  backgroundColor: "#fff",
-                  color: "#0347c1",
                   border: "3px solid #022a6e",
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
                   fontSize: "13px",
                   boxShadow: "3px 3px 0 #022a6e",
                   textDecoration: "none",
@@ -174,13 +157,9 @@ export function FeaturedPost() {
                 Ler Manifesto
               </Link>
               <button
-                className="px-5 py-2.5 cursor-pointer"
+                className="px-5 py-2.5 cursor-pointer font-grotesk font-bold bg-chrome-blue-mid text-chrome-blue-content"
                 style={{
-                  backgroundColor: "#0458d4",
-                  color: "#c8e0ff",
                   border: "3px solid #0560e0",
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
                   fontSize: "13px",
                   boxShadow: "3px 3px 0 #022a6e",
                   transition: "transform 0.2s ease, box-shadow 0.2s ease",

--- a/components/content/FeaturedPost.tsx
+++ b/components/content/FeaturedPost.tsx
@@ -45,7 +45,7 @@ export function FeaturedPost() {
                 style={{
                   height: "40%",
                   background: "linear-gradient(to top, rgba(3,71,193,0.3), transparent)",
-                  backdropFilter: "blur(2px)",
+                  backdropFilter: "blur(1px)",
                 }}
               />
             </div>
@@ -80,7 +80,7 @@ export function FeaturedPost() {
                 style={{
                   height: "40%",
                   background: "linear-gradient(to top, rgba(3,71,193,0.3), transparent)",
-                  backdropFilter: "blur(2px)",
+                  backdropFilter: "blur(1px)",
                 }}
               />
             </div>

--- a/components/content/NowPlaying.tsx
+++ b/components/content/NowPlaying.tsx
@@ -84,13 +84,10 @@ function MarqueeText({ text, playing }: { text: string; playing: boolean }) {
     >
       <span
         ref={textRef}
-        className="inline-block"
+        className="inline-block font-grotesk font-bold text-white"
         style={{
           animation: shouldScroll && playing ? "marqueeScroll 8s linear infinite" : "none",
-          fontFamily: "'Space Grotesk', sans-serif",
-          fontWeight: 700,
           fontSize: "13px",
-          color: "#fff",
         }}
       >
         {text}
@@ -144,32 +141,15 @@ export function MusicConsentBar({
 
         <div className="flex items-center gap-3 relative z-10 flex-1 min-w-0">
           <div
-            className="w-9 h-9 flex items-center justify-center flex-shrink-0"
-            style={{
-              border: "2px solid #80b0ff",
-              backgroundColor: "#0458d4",
-            }}
+            className="w-9 h-9 flex items-center justify-center flex-shrink-0 border-2 border-chrome-blue-soft bg-chrome-blue-mid"
           >
             <Music size={16} color="#4ade80" />
           </div>
           <div className="min-w-0">
-            <div
-              style={{
-                fontFamily: "'Space Grotesk', sans-serif",
-                fontWeight: 700,
-                fontSize: "13px",
-                color: "#fff",
-              }}
-            >
+            <div className="font-grotesk font-bold text-white" style={{ fontSize: "13px" }}>
               Quer ouvir música?
             </div>
-            <div
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "9px",
-                color: "#c8e0ff",
-              }}
-            >
+            <div className="font-mono text-chrome-blue-text-on-dark" style={{ fontSize: "9px" }}>
               Toque uma playlist enquanto navega pelo blog
             </div>
           </div>
@@ -178,14 +158,9 @@ export function MusicConsentBar({
         <div className="flex items-center gap-2 relative z-10 flex-shrink-0">
           <button
             onClick={onAccept}
-            className="px-4 py-1.5 cursor-pointer"
+            className="px-4 py-1.5 cursor-pointer font-grotesk font-bold text-chrome-blue bg-white border-2 border-chrome-blue-dark"
             style={{
-              border: "2px solid #022a6e",
-              backgroundColor: "#fff",
-              fontFamily: "'Space Grotesk', sans-serif",
-              fontWeight: 700,
               fontSize: "12px",
-              color: "#0347c1",
               boxShadow: "2px 2px 0 #022a6e",
               transition: "transform 0.15s, box-shadow 0.15s",
             }}
@@ -202,14 +177,10 @@ export function MusicConsentBar({
           </button>
           <button
             onClick={onDecline}
-            className="px-4 py-1.5 cursor-pointer"
+            className="px-4 py-1.5 cursor-pointer font-grotesk font-bold text-chrome-blue-text-on-dark border-2 border-chrome-blue-accent"
             style={{
-              border: "2px solid #0560e0",
-              backgroundColor: "transparent",
-              fontFamily: "'Space Grotesk', sans-serif",
-              fontWeight: 700,
               fontSize: "12px",
-              color: "#c8e0ff",
+              backgroundColor: "transparent",
               transition: "background 0.15s",
             }}
             onMouseEnter={(e) => {
@@ -325,10 +296,9 @@ export function NowPlayingWidget() {
   if (minimized) {
     return (
       <div
-        className="flex items-center gap-3 px-4 py-2 cursor-pointer"
+        className="flex items-center gap-3 px-4 py-2 cursor-pointer bg-chrome-blue"
         style={{
           border: "3px solid #022a6e",
-          backgroundColor: "#0347c1",
           boxShadow: "4px 4px 0 #022a6e",
         }}
         onClick={() => setMinimized(false)}
@@ -336,12 +306,8 @@ export function NowPlayingWidget() {
         <audio ref={audioRef} src={track.src} preload="auto" />
         <EqualizerBars playing={playing} barCount={4} />
         <span
-          className="flex-1 truncate"
-          style={{
-            fontFamily: "'Space Mono', monospace",
-            fontSize: "11px",
-            color: "#c8e0ff",
-          }}
+          className="flex-1 truncate font-mono text-chrome-blue-text-on-dark"
+          style={{ fontSize: "11px" }}
         >
           {track.artist} — {track.title}
         </span>
@@ -350,8 +316,8 @@ export function NowPlayingWidget() {
             e.stopPropagation();
             togglePlay();
           }}
-          className="cursor-pointer flex-shrink-0"
-          style={{ color: "#fff", background: "none", border: "none" }}
+          className="cursor-pointer flex-shrink-0 text-white"
+          style={{ background: "none", border: "none" }}
         >
           {playing ? <Pause size={14} /> : <Play size={14} />}
         </button>
@@ -395,9 +361,8 @@ export function NowPlayingWidget() {
 
       {/* Title bar — Winamp style */}
       <div
-        className="flex items-center justify-between px-3 py-1"
+        className="flex items-center justify-between px-3 py-1 bg-chrome-blue-mid"
         style={{
-          backgroundColor: "#0458d4",
           borderBottom: "2px solid #022a6e",
           minHeight: "26px",
         }}
@@ -405,13 +370,8 @@ export function NowPlayingWidget() {
         <div className="flex items-center gap-2">
           <EqualizerBars playing={playing} barCount={3} />
           <span
-            style={{
-              fontFamily: "'Space Mono', monospace",
-              fontSize: "10px",
-              fontWeight: 700,
-              color: "#c8e0ff",
-              letterSpacing: "0.05em",
-            }}
+            className="font-mono font-bold text-chrome-blue-content"
+            style={{ fontSize: "10px", letterSpacing: "0.05em" }}
           >
             PLAYER.EXE
           </span>
@@ -419,35 +379,23 @@ export function NowPlayingWidget() {
         <div className="flex items-center gap-1.5">
           <button
             onClick={() => setMinimized(true)}
-            className="w-4 h-4 flex items-center justify-center cursor-pointer"
-            style={{
-              border: "2px solid #022a6e",
-              backgroundColor: "#0560e0",
-              fontSize: "10px",
-              fontWeight: 700,
-              lineHeight: 1,
-              color: "#fff",
-            }}
+            className="w-4 h-4 flex items-center justify-center cursor-pointer font-bold text-white bg-chrome-blue-accent border-2 border-chrome-blue-dark"
+            style={{ fontSize: "10px", lineHeight: 1 }}
           >
             _
           </button>
           <div
-            className="w-4 h-4"
-            style={{ border: "2px solid #022a6e", backgroundColor: "#e05050" }}
+            className="w-4 h-4 bg-chrome-red border-2 border-chrome-blue-dark"
           />
         </div>
       </div>
 
       {/* Player body */}
-      <div className="flex items-center gap-3 px-4 py-3" style={{ backgroundColor: "#0347c1" }}>
+      <div className="flex items-center gap-3 px-4 py-3 bg-chrome-blue">
         {/* Vinyl / Album art placeholder */}
         <div
-          className="w-11 h-11 flex-shrink-0 flex items-center justify-center relative"
-          style={{
-            border: "2px solid #80b0ff",
-            backgroundColor: "#022a6e",
-            overflow: "hidden",
-          }}
+          className="w-11 h-11 flex-shrink-0 flex items-center justify-center relative border-2 border-chrome-blue-soft bg-chrome-blue-dark"
+          style={{ overflow: "hidden" }}
         >
           <div
             className="absolute inset-0 flex items-center justify-center"
@@ -471,12 +419,8 @@ export function NowPlayingWidget() {
         <div className="flex-1 min-w-0">
           <MarqueeText text={`${track.title} — ${track.artist}`} playing={playing} />
           <div
-            style={{
-              fontFamily: "'Space Mono', monospace",
-              fontSize: "9px",
-              color: "#a0c4ff",
-              marginTop: 1,
-            }}
+            className="font-mono text-chrome-blue-body"
+            style={{ fontSize: "9px", marginTop: 1 }}
           >
             {track.album} · Track {currentTrack + 1}/{TRACKS.length}
           </div>
@@ -484,31 +428,19 @@ export function NowPlayingWidget() {
           {/* Progress bar */}
           <div className="flex items-center gap-2 mt-2">
             <span
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "8px",
-                color: "#a0c4ff",
-                minWidth: 28,
-              }}
+              className="font-mono text-chrome-blue-body"
+              style={{ fontSize: "8px", minWidth: 28 }}
             >
               {formatTime(progress)}
             </span>
             <div
               ref={progressBarRef}
-              className="flex-1 h-2 cursor-pointer relative"
-              style={{
-                border: "2px solid #0560e0",
-                backgroundColor: "#022a6e",
-              }}
+              className="flex-1 h-2 cursor-pointer relative border-2 border-chrome-blue-accent bg-chrome-blue-dark"
               onClick={seekTo}
             >
               <div
-                className="h-full"
-                style={{
-                  width: `${pct}%`,
-                  backgroundColor: "#4ade80",
-                  transition: "width 0.1s linear",
-                }}
+                className="h-full bg-chrome-green"
+                style={{ width: `${pct}%`, transition: "width 0.1s linear" }}
               />
               <div
                 className="absolute inset-0 pointer-events-none"
@@ -518,13 +450,8 @@ export function NowPlayingWidget() {
               />
             </div>
             <span
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "8px",
-                color: "#a0c4ff",
-                minWidth: 28,
-                textAlign: "right",
-              }}
+              className="font-mono text-chrome-blue-body"
+              style={{ fontSize: "8px", minWidth: 28, textAlign: "right" }}
             >
               {formatTime(duration)}
             </span>
@@ -535,13 +462,8 @@ export function NowPlayingWidget() {
             <div className="flex items-center gap-1">
               <button
                 onClick={prevTrack}
-                className="w-7 h-7 flex items-center justify-center cursor-pointer"
-                style={{
-                  border: "2px solid #0560e0",
-                  backgroundColor: "#0458d4",
-                  color: "#c8e0ff",
-                  transition: "background 0.15s",
-                }}
+                className="w-7 h-7 flex items-center justify-center cursor-pointer border-2 border-chrome-blue-accent bg-chrome-blue-mid text-chrome-blue-content"
+                style={{ transition: "background 0.15s" }}
                 onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#0560e0")}
                 onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "#0458d4")}
               >
@@ -550,11 +472,8 @@ export function NowPlayingWidget() {
 
               <button
                 onClick={togglePlay}
-                className="w-8 h-8 flex items-center justify-center cursor-pointer"
+                className="w-8 h-8 flex items-center justify-center cursor-pointer bg-white text-chrome-blue border-2 border-chrome-blue-dark"
                 style={{
-                  border: "2px solid #022a6e",
-                  backgroundColor: "#fff",
-                  color: "#0347c1",
                   boxShadow: "2px 2px 0 #022a6e",
                   transition: "transform 0.15s, box-shadow 0.15s",
                 }}
@@ -572,13 +491,8 @@ export function NowPlayingWidget() {
 
               <button
                 onClick={nextTrack}
-                className="w-7 h-7 flex items-center justify-center cursor-pointer"
-                style={{
-                  border: "2px solid #0560e0",
-                  backgroundColor: "#0458d4",
-                  color: "#c8e0ff",
-                  transition: "background 0.15s",
-                }}
+                className="w-7 h-7 flex items-center justify-center cursor-pointer border-2 border-chrome-blue-accent bg-chrome-blue-mid text-chrome-blue-content"
+                style={{ transition: "background 0.15s" }}
                 onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#0560e0")}
                 onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "#0458d4")}
               >
@@ -590,8 +504,8 @@ export function NowPlayingWidget() {
             <div className="flex items-center gap-1.5">
               <button
                 onClick={() => setMuted(!muted)}
-                className="cursor-pointer"
-                style={{ color: "#c8e0ff", background: "none", border: "none" }}
+                className="cursor-pointer text-chrome-blue-content"
+                style={{ background: "none", border: "none" }}
               >
                 {muted || volume === 0 ? <VolumeX size={13} /> : <Volume2 size={13} />}
               </button>
@@ -616,7 +530,7 @@ export function NowPlayingWidget() {
       </div>
 
       {/* Track list — foobar2000 style */}
-      <div style={{ borderTop: "2px solid #022a6e", backgroundColor: "#022a6e" }}>
+      <div className="bg-chrome-blue-dark" style={{ borderTop: "2px solid #022a6e" }}>
         {TRACKS.map((t, i) => (
           <div
             key={i}
@@ -639,8 +553,8 @@ export function NowPlayingWidget() {
             }}
           >
             <span
+              className="font-mono"
               style={{
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "9px",
                 color: i === currentTrack ? "#4ade80" : "#a0c4ff",
                 width: 16,
@@ -651,9 +565,8 @@ export function NowPlayingWidget() {
               {i === currentTrack && playing ? "▶" : String(i + 1).padStart(2, "0")}
             </span>
             <span
-              className="flex-1 truncate"
+              className="flex-1 truncate font-grotesk"
               style={{
-                fontFamily: "'Space Grotesk', sans-serif",
                 fontSize: "11px",
                 fontWeight: i === currentTrack ? 700 : 400,
                 color: i === currentTrack ? "#fff" : "#c8e0ff",
@@ -662,12 +575,8 @@ export function NowPlayingWidget() {
               {t.artist} — {t.title}
             </span>
             <span
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "9px",
-                color: "#a0c4ff",
-                flexShrink: 0,
-              }}
+              className="font-mono text-chrome-blue-body"
+              style={{ fontSize: "9px", flexShrink: 0 }}
             >
               {t.duration}
             </span>

--- a/components/content/PostsGrid.tsx
+++ b/components/content/PostsGrid.tsx
@@ -42,23 +42,18 @@ export function PostsGrid() {
           />
           <div className="flex items-center gap-2 flex-shrink-0">
             <span
-              style={{
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "9px",
-                color: "var(--arm-panel-text-muted)",
-              }}
+              className="font-mono"
+              style={{ fontSize: "9px", color: "var(--arm-panel-text-muted)" }}
             >
               {posts.length} ENTRIES FOUND
             </span>
             <Link
               href="/posts"
-              className="px-4 py-1.5 cursor-pointer transition-all duration-150 hover:brightness-125 hover:-translate-y-px"
+              className="px-4 py-1.5 cursor-pointer transition-all duration-150 hover:brightness-125 hover:-translate-y-px font-mono font-bold"
               style={{
                 border: "2px solid var(--arm-panel-border)",
                 backgroundColor: "var(--arm-panel-bg)",
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "11px",
-                fontWeight: 700,
                 color: "var(--arm-panel-text-soft)",
                 textDecoration: "none",
                 display: "inline-block",
@@ -110,8 +105,8 @@ export function PostsGrid() {
                 }}
               >
                 <span
+                  className="font-mono"
                   style={{
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "8px",
                     color: post.isCorrupted ? "#ff4444" : "var(--arm-panel-text-muted)",
                   }}
@@ -129,11 +124,8 @@ export function PostsGrid() {
                     }}
                   />
                   <div
-                    className="w-2 h-2"
-                    style={{
-                      backgroundColor: "#e05050",
-                      border: "1px solid var(--arm-panel-bg-deep)",
-                    }}
+                    className="w-2 h-2 bg-chrome-red"
+                    style={{ border: "1px solid var(--arm-panel-bg-deep)" }}
                   />
                 </div>
               </div>
@@ -155,13 +147,11 @@ export function PostsGrid() {
                   }}
                 />
                 <div
-                  className="absolute top-2 left-2 px-2 py-0.5"
+                  className="absolute top-2 left-2 px-2 py-0.5 font-mono font-bold"
                   style={{
                     backgroundColor: categoryColors[post.category] || "var(--arm-panel-bg-darker)",
                     border: "2px solid var(--arm-panel-bg-deep)",
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "8px",
-                    fontWeight: 700,
                     color: "var(--arm-panel-bg-deep)",
                     boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
                   }}
@@ -179,10 +169,8 @@ export function PostsGrid() {
               {/* Content */}
               <div className="p-3 flex flex-col flex-1 overflow-hidden">
                 <h3
-                  className="line-clamp-2"
+                  className="line-clamp-2 font-grotesk font-bold"
                   style={{
-                    fontFamily: "'Space Grotesk', sans-serif",
-                    fontWeight: 700,
                     fontSize: "13px",
                     color: "var(--arm-panel-text)",
                     lineHeight: 1.3,
@@ -192,9 +180,8 @@ export function PostsGrid() {
                   {post.title}
                 </h3>
                 <p
-                  className="flex-1 line-clamp-3"
+                  className="flex-1 line-clamp-3 font-mono"
                   style={{
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "10px",
                     lineHeight: 1.5,
                     color: "var(--arm-panel-text-soft)",
@@ -214,7 +201,7 @@ export function PostsGrid() {
                     style={{ color: "var(--arm-panel-text-muted)" }}
                   >
                     <Clock size={10} />
-                    <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}>
+                    <span className="font-mono" style={{ fontSize: "8px" }}>
                       {post.date}
                     </span>
                   </div>
@@ -223,7 +210,7 @@ export function PostsGrid() {
                     style={{ color: "var(--arm-panel-text-muted)" }}
                   >
                     <Eye size={10} />
-                    <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}>
+                    <span className="font-mono" style={{ fontSize: "8px" }}>
                       {post.reads}
                     </span>
                   </div>
@@ -232,7 +219,7 @@ export function PostsGrid() {
                     style={{ color: "var(--arm-panel-text-muted)" }}
                   >
                     <MessageCircle size={10} />
-                    <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "8px" }}>
+                    <span className="font-mono" style={{ fontSize: "8px" }}>
                       {post.comments}
                     </span>
                   </div>

--- a/components/content/SideContent.tsx
+++ b/components/content/SideContent.tsx
@@ -58,9 +58,8 @@ export function SideContent() {
               </div>
               <div className="min-w-0">
                 <div
+                  className="font-grotesk font-bold"
                   style={{
-                    fontFamily: "'Space Grotesk', sans-serif",
-                    fontWeight: 700,
                     fontSize: "12px",
                     lineHeight: 1.3,
                     color: "var(--arm-text)",
@@ -69,8 +68,8 @@ export function SideContent() {
                   {item.title}
                 </div>
                 <div
+                  className="font-mono"
                   style={{
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "9px",
                     color: "var(--arm-text-secondary)",
                   }}
@@ -87,11 +86,8 @@ export function SideContent() {
             <polygon points="0,0 0,16 4,12 8,20 10,19 6,11 12,11" fill="var(--arm-text)" />
           </svg>
           <div
-            style={{
-              fontFamily: "'Space Mono', monospace",
-              fontSize: "9px",
-              color: "var(--arm-text)",
-            }}
+            className="font-mono"
+            style={{ fontSize: "9px", color: "var(--arm-text)" }}
           >
             CLICK TO EXPLORE...
           </div>

--- a/components/content/single-post/AuthorCard.tsx
+++ b/components/content/single-post/AuthorCard.tsx
@@ -45,23 +45,14 @@ export function AuthorCard({ author }: AuthorCardProps) {
             color="#fff"
           />
           <div
-            style={{
-              fontFamily: "'Space Mono', monospace",
-              fontSize: "10px",
-              color: "#4ade80",
-              marginTop: "2px",
-            }}
+            className="font-mono text-chrome-green"
+            style={{ fontSize: "10px", marginTop: "2px" }}
           >
             {author.role}
           </div>
           <p
-            className="mt-2"
-            style={{
-              fontFamily: "'Space Grotesk', sans-serif",
-              fontSize: "13px",
-              lineHeight: 1.6,
-              color: "#c8e0ff",
-            }}
+            className="mt-2 font-grotesk text-chrome-blue-content"
+            style={{ fontSize: "13px", lineHeight: 1.6 }}
           >
             {author.bio}
           </p>

--- a/components/content/single-post/PostCommentsSection.tsx
+++ b/components/content/single-post/PostCommentsSection.tsx
@@ -59,8 +59,8 @@ export function PostCommentsSection({ comments }: PostCommentsSectionProps) {
             color="#fff"
           />
           <span
-            className="flex-shrink-0"
-            style={{ fontFamily: "'Space Mono', monospace", fontSize: "9px", color: "#a0c4ff" }}
+            className="flex-shrink-0 font-mono text-chrome-blue-body"
+            style={{ fontSize: "9px" }}
           >
             {comments.length} RESPONSES
           </span>
@@ -68,38 +68,24 @@ export function PostCommentsSection({ comments }: PostCommentsSectionProps) {
 
         {/* Comment input */}
         <div
-          className="mb-5 p-3"
-          style={{ border: "2px solid #0560e0", backgroundColor: "#0458d4" }}
+          className="mb-5 p-3 border-2 border-chrome-blue-accent bg-chrome-blue-mid"
         >
           <div
-            className="mb-2"
-            style={{ fontFamily: "'Space Mono', monospace", fontSize: "9px", color: "#a0c4ff" }}
+            className="mb-2 font-mono text-chrome-blue-body"
+            style={{ fontSize: "9px" }}
           >
             {">"} ESCREVA SEU COMENTARIO_
           </div>
           <textarea
             placeholder="O que voce achou deste manifesto?..."
-            className="w-full bg-transparent outline-none resize-none"
+            className="w-full bg-transparent outline-none resize-none font-grotesk text-chrome-blue-content"
             rows={3}
-            style={{
-              fontFamily: "'Space Grotesk', sans-serif",
-              fontSize: "13px",
-              color: "#c0d8ff",
-              border: "none",
-            }}
+            style={{ fontSize: "13px", border: "none" }}
           />
           <div className="flex justify-end mt-2">
             <button
-              className="px-4 py-1.5 cursor-pointer"
-              style={{
-                backgroundColor: "#fff",
-                color: "#0347c1",
-                border: "2px solid #022a6e",
-                fontFamily: "'Space Mono', monospace",
-                fontSize: "10px",
-                fontWeight: 700,
-                boxShadow: "2px 2px 0 #022a6e",
-              }}
+              className="px-4 py-1.5 cursor-pointer font-mono font-bold bg-white text-chrome-blue border-2 border-chrome-blue-dark"
+              style={{ fontSize: "10px", boxShadow: "2px 2px 0 #022a6e" }}
             >
               ENVIAR
             </button>
@@ -188,24 +174,18 @@ export function PostCommentsSection({ comments }: PostCommentsSectionProps) {
                       }}
                     />
                     <span
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "8px",
-                        color: "#a0c4ff",
-                        letterSpacing: "0.05em",
-                      }}
+                      className="font-mono text-chrome-blue-body"
+                      style={{ fontSize: "8px", letterSpacing: "0.05em" }}
                     >
                       COMMENT-{String(globalIndex + 1).padStart(2, "0")}.TXT
                     </span>
                   </div>
                   <div className="flex gap-1">
                     <div
-                      className="w-2 h-2"
-                      style={{ backgroundColor: "#0560e0", border: "1px solid #022a6e" }}
+                      className="w-2 h-2 bg-chrome-blue-accent border border-chrome-blue-dark"
                     />
                     <div
-                      className="w-2 h-2"
-                      style={{ backgroundColor: "#e05050", border: "1px solid #022a6e" }}
+                      className="w-2 h-2 bg-chrome-red border border-chrome-blue-dark"
                     />
                   </div>
                 </div>
@@ -232,12 +212,8 @@ export function PostCommentsSection({ comments }: PostCommentsSectionProps) {
                           />
                         </div>
                         <div
-                          className="absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full"
-                          style={{
-                            backgroundColor: "#4ade80",
-                            border: "2px solid #0347c1",
-                            boxShadow: "0 0 6px #4ade8060",
-                          }}
+                          className="absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full bg-chrome-green border-2 border-chrome-blue"
+                          style={{ boxShadow: "0 0 6px #4ade8060" }}
                         />
                       </div>
                       <div className="min-w-0">
@@ -321,14 +297,8 @@ export function PostCommentsSection({ comments }: PostCommentsSectionProps) {
                       &gt;
                     </span>
                     <p
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "10px",
-                        lineHeight: 1.7,
-                        color: "#a0c4ff",
-                        paddingLeft: "14px",
-                        paddingTop: "1px",
-                      }}
+                      className="font-mono text-chrome-blue-body"
+                      style={{ fontSize: "10px", lineHeight: 1.7, paddingLeft: "14px", paddingTop: "1px" }}
                     >
                       {comment.text}
                     </p>
@@ -343,13 +313,11 @@ export function PostCommentsSection({ comments }: PostCommentsSectionProps) {
                       {reactions.map((r, ri) => (
                         <button
                           key={ri}
-                          className="flex items-center gap-1 px-1.5 py-0.5 cursor-pointer"
+                          className="flex items-center gap-1 px-1.5 py-0.5 cursor-pointer font-mono text-chrome-blue-body"
                           style={{
                             backgroundColor: "transparent",
                             border: `1px solid ${accent}25`,
-                            fontFamily: "'Space Mono', monospace",
                             fontSize: "9px",
-                            color: "#a0c4ff",
                             transition: "all 0.15s ease",
                           }}
                           onMouseEnter={(e) => {
@@ -369,12 +337,8 @@ export function PostCommentsSection({ comments }: PostCommentsSectionProps) {
                       ))}
                     </div>
                     <span
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "8px",
-                        color: "#3a6aaa",
-                        letterSpacing: "0.03em",
-                      }}
+                      className="font-mono text-chrome-blue-dim"
+                      style={{ fontSize: "8px", letterSpacing: "0.03em" }}
                     >
                       {comment.date}
                     </span>

--- a/components/content/single-post/PostHero.tsx
+++ b/components/content/single-post/PostHero.tsx
@@ -118,15 +118,12 @@ export function PostHero({
         <div className="flex flex-col gap-2 mb-5">
           <Link
             href="/"
-            className="inline-flex items-center gap-2 px-3 py-1.5 self-start"
+            className="inline-flex items-center gap-2 px-3 py-1.5 self-start font-mono font-bold text-white"
             style={{
               background: "rgba(255,255,255,0.12)",
               backdropFilter: "blur(12px)",
               border: "2px solid rgba(255,255,255,0.25)",
-              color: "#fff",
-              fontFamily: "'Space Mono', monospace",
               fontSize: "10px",
-              fontWeight: 700,
               textDecoration: "none",
               boxShadow: "0 4px 16px rgba(0,0,0,0.15)",
             }}
@@ -141,8 +138,8 @@ export function PostHero({
                 {crumb.href ? (
                   <Link
                     href={crumb.href}
+                    className="font-mono"
                     style={{
-                      fontFamily: "'Space Mono', monospace",
                       fontSize: "9px",
                       color: "rgba(255,255,255,0.6)",
                       textDecoration: "none",
@@ -152,20 +149,16 @@ export function PostHero({
                   </Link>
                 ) : i < arr.length - 1 ? (
                   <span
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "9px",
-                      color: "rgba(255,255,255,0.6)",
-                    }}
+                    className="font-mono"
+                    style={{ fontSize: "9px", color: "rgba(255,255,255,0.6)" }}
                   >
                     {crumb.label}
                   </span>
                 ) : (
                   <span
+                    className="font-mono text-white"
                     style={{
-                      fontFamily: "'Space Mono', monospace",
                       fontSize: "9px",
-                      color: "#fff",
                       maxWidth: "200px",
                       overflow: "hidden",
                       textOverflow: "ellipsis",
@@ -184,24 +177,17 @@ export function PostHero({
         {/* Category + date */}
         <div className="flex items-center gap-3 mb-3">
           <span
-            className="px-2.5 py-0.5"
+            className="px-2.5 py-0.5 font-mono font-bold text-chrome-blue-dark border-2 border-chrome-blue-dark"
             style={{
               backgroundColor: categoryColors[category] || "#0347c1",
-              border: "2px solid #022a6e",
-              fontFamily: "'Space Mono', monospace",
               fontSize: "9px",
-              fontWeight: 700,
-              color: "#022a6e",
             }}
           >
             {category.toUpperCase()}
           </span>
           <span
-            style={{
-              fontFamily: "'Space Mono', monospace",
-              fontSize: "10px",
-              color: "rgba(255,255,255,0.7)",
-            }}
+            className="font-mono"
+            style={{ fontSize: "10px", color: "rgba(255,255,255,0.7)" }}
           >
             {date} · {readTime} de leitura
           </span>
@@ -219,13 +205,8 @@ export function PostHero({
 
         {/* Subtitle */}
         <p
-          className="mt-3 max-w-[650px]"
-          style={{
-            fontFamily: "'Space Grotesk', sans-serif",
-            fontSize: "16px",
-            lineHeight: 1.5,
-            color: "rgba(255,255,255,0.8)",
-          }}
+          className="mt-3 max-w-[650px] font-grotesk"
+          style={{ fontSize: "16px", lineHeight: 1.5, color: "rgba(255,255,255,0.8)" }}
         >
           {subtitle}
         </p>
@@ -253,21 +234,12 @@ export function PostHero({
               style={{ color: "rgba(255,255,255,0.8)" }}
             >
               <stat.icon size={14} />
-              <span
-                style={{
-                  fontFamily: "'Space Grotesk', sans-serif",
-                  fontWeight: 700,
-                  fontSize: "14px",
-                }}
-              >
+              <span className="font-grotesk font-bold" style={{ fontSize: "14px" }}>
                 {stat.value}
               </span>
               <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "rgba(255,255,255,0.5)",
-                }}
+                className="font-mono"
+                style={{ fontSize: "9px", color: "rgba(255,255,255,0.5)" }}
               >
                 {stat.label}
               </span>

--- a/components/content/single-post/RelatedPosts.tsx
+++ b/components/content/single-post/RelatedPosts.tsx
@@ -27,30 +27,22 @@ export function RelatedPosts({ posts, categoryColors }: RelatedPostsProps) {
             <Link
               key={post.id}
               href={`/post/${post.slug}`}
-              className="flex flex-col group"
-              style={{
-                border: "2px solid #0560e0",
-                backgroundColor: "#0458d4",
-                textDecoration: "none",
-              }}
+              className="flex flex-col group border-2 border-chrome-blue-accent bg-chrome-blue-mid"
+              style={{ textDecoration: "none" }}
             >
               {/* Mini title bar */}
               <div
-                className="flex items-center justify-between px-2 py-1"
-                style={{ backgroundColor: "#0560e0", borderBottom: "2px solid #0560e0" }}
+                className="flex items-center justify-between px-2 py-1 bg-chrome-blue-accent"
+                style={{ borderBottom: "2px solid #0560e0" }}
               >
                 <span
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "8px",
-                    color: "#a0c4ff",
-                  }}
+                  className="font-mono text-chrome-blue-body"
+                  style={{ fontSize: "8px" }}
                 >
                   RELATED-{String(post.id).padStart(2, "0")}.MD
                 </span>
                 <div
-                  className="w-2 h-2"
-                  style={{ backgroundColor: "#e05050", border: "1px solid #022a6e" }}
+                  className="w-2 h-2 bg-chrome-red border border-chrome-blue-dark"
                 />
               </div>
 
@@ -77,14 +69,11 @@ export function RelatedPosts({ posts, categoryColors }: RelatedPostsProps) {
                   }}
                 />
                 <div
-                  className="absolute top-1.5 left-1.5 px-1.5 py-0.5"
+                  className="absolute top-1.5 left-1.5 px-1.5 py-0.5 font-mono font-bold text-chrome-blue-dark"
                   style={{
                     backgroundColor: categoryColors[post.category] || "#0347c1",
                     border: "1.5px solid #022a6e",
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "7px",
-                    fontWeight: 700,
-                    color: "#022a6e",
                   }}
                 >
                   {post.category.toUpperCase()}
@@ -93,24 +82,14 @@ export function RelatedPosts({ posts, categoryColors }: RelatedPostsProps) {
 
               <div className="p-3">
                 <h4
-                  style={{
-                    fontFamily: "'Space Grotesk', sans-serif",
-                    fontWeight: 700,
-                    fontSize: "12px",
-                    color: "#fff",
-                    lineHeight: 1.3,
-                    marginBottom: "4px",
-                  }}
+                  className="font-grotesk font-bold text-white"
+                  style={{ fontSize: "12px", lineHeight: 1.3, marginBottom: "4px" }}
                 >
                   {post.title}
                 </h4>
                 <p
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "9px",
-                    lineHeight: 1.5,
-                    color: "#c8e0ff",
-                  }}
+                  className="font-mono text-chrome-blue-content"
+                  style={{ fontSize: "9px", lineHeight: 1.5 }}
                 >
                   {post.excerpt}
                 </p>

--- a/components/content/single-post/TableOfContents.tsx
+++ b/components/content/single-post/TableOfContents.tsx
@@ -51,10 +51,9 @@ export function TableOfContents({ sections, readTime, reads }: TableOfContentsPr
         }}
       >
         <span
+          className="font-mono font-bold"
           style={{
-            fontFamily: "'Space Mono', monospace",
             fontSize: "9px",
-            fontWeight: 700,
             color: "var(--arm-text)",
             letterSpacing: "0.05em",
           }}
@@ -70,16 +69,15 @@ export function TableOfContents({ sections, readTime, reads }: TableOfContentsPr
             }}
           />
           <div
-            className="w-2.5 h-2.5"
-            style={{ backgroundColor: "#e05050", border: "1.5px solid var(--arm-border)" }}
+            className="w-2.5 h-2.5 bg-chrome-red"
+            style={{ border: "1.5px solid var(--arm-border)" }}
           />
         </div>
       </div>
       <div className="p-4">
         <div
+          className="font-grotesk font-bold"
           style={{
-            fontFamily: "'Space Grotesk', sans-serif",
-            fontWeight: 700,
             fontSize: "13px",
             color: "var(--arm-text)",
             marginBottom: "12px",
@@ -106,10 +104,9 @@ export function TableOfContents({ sections, readTime, reads }: TableOfContentsPr
                 }}
               >
                 <span
+                  className="font-mono font-bold"
                   style={{
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: "9px",
-                    fontWeight: 700,
                     color: isActive ? "var(--arm-blue)" : "var(--arm-text-secondary)",
                     minWidth: "16px",
                   }}
@@ -117,8 +114,8 @@ export function TableOfContents({ sections, readTime, reads }: TableOfContentsPr
                   {String(i + 1).padStart(2, "0")}
                 </span>
                 <span
+                  className="font-grotesk"
                   style={{
-                    fontFamily: "'Space Grotesk', sans-serif",
                     fontSize: "12px",
                     fontWeight: isActive ? 700 : 500,
                     color: isActive ? "var(--arm-text)" : "var(--arm-text-secondary)",
@@ -138,13 +135,13 @@ export function TableOfContents({ sections, readTime, reads }: TableOfContentsPr
         >
           <div className="flex items-center gap-1" style={{ color: "#5a6a8e" }}>
             <Clock size={11} />
-            <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "9px" }}>
+            <span className="font-mono" style={{ fontSize: "9px" }}>
               {readTime}
             </span>
           </div>
           <div className="flex items-center gap-1" style={{ color: "#5a6a8e" }}>
             <Eye size={11} />
-            <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "9px" }}>{reads}</span>
+            <span className="font-mono" style={{ fontSize: "9px" }}>{reads}</span>
           </div>
         </div>
       </div>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -35,10 +35,9 @@ export function Footer({ contextLabel }: FooterProps) {
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <div
+              className="font-bungee font-bold"
               style={{
-                fontFamily: "'Bungee Shade', sans-serif",
                 fontSize: "14px",
-                fontWeight: 700,
                 color: "var(--arm-blue)",
                 letterSpacing: "0.08em",
                 opacity: "var(--arm-brand-opacity)",
@@ -47,8 +46,8 @@ export function Footer({ contextLabel }: FooterProps) {
               ARMANDO
             </div>
             <span
+              className="font-mono"
               style={{
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "9px",
                 color: "var(--arm-text-secondary)",
               }}
@@ -94,8 +93,8 @@ export function Footer({ contextLabel }: FooterProps) {
             <Link
               key={link.path}
               href={link.path}
+              className="font-mono"
               style={{
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "10px",
                 color: "var(--arm-text-secondary)",
                 textDecoration: "none",
@@ -117,8 +116,8 @@ export function Footer({ contextLabel }: FooterProps) {
         {/* Bottom bar */}
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
           <span
+            className="font-mono"
             style={{
-              fontFamily: "'Space Mono', monospace",
               fontSize: "9px",
               color: "var(--arm-text-muted)",
               letterSpacing: "0.05em",

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -93,8 +93,8 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
 
   return (
     <header
-      className="flex items-center justify-between px-3 sm:px-6 py-3 relative flex-shrink-0"
-      style={{ borderBottom: "3px solid #022a6e", backgroundColor: "#0347c1", zIndex: 50 }}
+      className="flex items-center justify-between px-3 sm:px-6 py-3 relative flex-shrink-0 bg-chrome-blue"
+      style={{ borderBottom: "3px solid #022a6e", zIndex: 50 }}
     >
       {/* Glass sheen */}
       <div
@@ -122,8 +122,7 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
 
       {/* Hamburger — mobile */}
       <button
-        className="lg:hidden flex items-center justify-center w-9 h-9 cursor-pointer flex-shrink-0 mr-2 relative z-10"
-        style={{ border: "2px solid #0560e0", backgroundColor: "#0458d4", color: "#c8e0ff" }}
+        className="lg:hidden flex items-center justify-center w-9 h-9 cursor-pointer flex-shrink-0 mr-2 relative z-10 border-2 border-chrome-blue-accent bg-chrome-blue-mid text-chrome-blue-content"
         onClick={onMobileMenuToggle}
         aria-label="Abrir menu"
       >
@@ -132,8 +131,7 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
 
       {/* Back button — desktop */}
       <button
-        className="hidden lg:flex items-center justify-center w-9 h-9 cursor-pointer flex-shrink-0 relative z-10"
-        style={{ border: "2px solid #0560e0", backgroundColor: "#0458d4", color: "#c8e0ff" }}
+        className="hidden lg:flex items-center justify-center w-9 h-9 cursor-pointer flex-shrink-0 relative z-10 border-2 border-chrome-blue-accent bg-chrome-blue-mid text-chrome-blue-content"
         onClick={() => router.back()}
         title="Voltar"
       >
@@ -143,11 +141,9 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
       {/* Search bar */}
       <div ref={searchRef} className="relative flex-1 mx-2 sm:mx-5 z-10">
         <div
-          className="flex items-center px-3 py-1.5"
+          className="flex items-center px-3 py-1.5 font-mono bg-chrome-blue-mid"
           style={{
             border: searchFocused ? "2px solid #4ade80" : "2px solid #0560e0",
-            backgroundColor: "#0458d4",
-            fontFamily: "'Space Mono', monospace",
             transition: "border-color 0.2s",
           }}
         >
@@ -159,16 +155,16 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
           <input
             type="text"
             placeholder="pesquise aqui o que voce tem interesse!!"
-            className="flex-1 bg-transparent outline-none min-w-0"
-            style={{ fontSize: "12px", fontFamily: "'Space Mono', monospace", color: "#c0d8ff" }}
+            className="flex-1 bg-transparent outline-none min-w-0 font-mono text-chrome-blue-content"
+            style={{ fontSize: "12px" }}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             onFocus={() => setSearchFocused(true)}
           />
           {searchQuery && (
             <button
-              className="flex-shrink-0 cursor-pointer"
-              style={{ background: "none", border: "none", color: "#c8e0ff", padding: 0 }}
+              className="flex-shrink-0 cursor-pointer text-chrome-blue-content"
+              style={{ background: "none", border: "none", padding: 0 }}
               onClick={() => {
                 setSearchQuery("");
                 setSearchFocused(false);
@@ -182,30 +178,26 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
         {/* Search results dropdown */}
         {showSearchDropdown && (
           <div
-            className="absolute left-0 right-0 mt-1"
+            className="absolute left-0 right-0 mt-1 bg-chrome-blue"
             style={{
               border: "2.5px solid #022a6e",
               boxShadow: "4px 4px 0 #022a6e",
-              backgroundColor: "#0347c1",
               zIndex: 9999,
             }}
           >
             <div
-              className="px-3 py-1 flex items-center gap-2"
-              style={{ borderBottom: "2px solid #0560e0", backgroundColor: "#0458d4" }}
+              className="px-3 py-1 flex items-center gap-2 bg-chrome-blue-mid"
+              style={{ borderBottom: "2px solid #0560e0" }}
             >
               <span
-                style={{
-                  fontFamily: "'Space Mono', monospace",
-                  fontSize: "9px",
-                  color: "#c8e0ff",
-                  letterSpacing: "0.1em",
-                }}
+                className="font-mono text-chrome-blue-content"
+                style={{ fontSize: "9px", letterSpacing: "0.1em" }}
               >
                 SEARCH.EXE
               </span>
               <span
-                style={{ fontFamily: "'Space Mono', monospace", fontSize: "9px", color: "#4ade80" }}
+                className="font-mono text-chrome-green"
+                style={{ fontSize: "9px" }}
               >
                 {searchResults.length} resultado{searchResults.length !== 1 ? "s" : ""}
               </span>
@@ -236,21 +228,14 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
                   <Search size={11} style={{ color: "#a0c4ff", flexShrink: 0 }} />
                   <div className="flex-1 min-w-0">
                     <div
-                      className="truncate"
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontSize: "12px",
-                        color: "#e0eeff",
-                      }}
+                      className="truncate font-grotesk"
+                      style={{ fontSize: "12px", color: "#e0eeff" }}
                     >
                       {r.title}
                     </div>
                     <span
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "9px",
-                        color: "#a0c4ff",
-                      }}
+                      className="font-mono text-chrome-blue-body"
+                      style={{ fontSize: "9px" }}
                     >
                       {r.category.toUpperCase()}
                     </span>
@@ -260,11 +245,8 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
             ) : (
               <div className="px-3 py-3 text-center">
                 <span
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "10px",
-                    color: "#a0c4ff",
-                  }}
+                  className="font-mono text-chrome-blue-body"
+                  style={{ fontSize: "10px" }}
                 >
                   NENHUM RESULTADO ENCONTRADO
                 </span>
@@ -278,12 +260,8 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
         {/* Bell + notification panel */}
         <div ref={panelRef} className="relative">
           <button
-            className="flex items-center justify-center w-9 h-9 relative cursor-pointer"
-            style={{
-              border: "2px solid #0560e0",
-              backgroundColor: notifOpen ? "#022a6e" : "#0458d4",
-              color: "#c8e0ff",
-            }}
+            className="flex items-center justify-center w-9 h-9 relative cursor-pointer border-2 border-chrome-blue-accent text-chrome-blue-content"
+            style={{ backgroundColor: notifOpen ? "#022a6e" : "#0458d4" }}
             onClick={() => setNotifOpen((v) => !v)}
             aria-label="Notificações"
           >
@@ -334,27 +312,15 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
                     />
                   </div>
                   <span
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: 10,
-                      color: "#c0d8ff",
-                      letterSpacing: "0.12em",
-                      textTransform: "uppercase",
-                    }}
+                    className="font-mono text-chrome-blue-content uppercase"
+                    style={{ fontSize: 10, letterSpacing: "0.12em" }}
                   >
                     NOTIFICAÇÕES
                   </span>
                   {unreadCount > 0 && (
                     <span
-                      className="px-1.5 py-0.5"
-                      style={{
-                        background: "#4ade80",
-                        color: "#022a6e",
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: 9,
-                        fontWeight: 700,
-                        border: "1px solid #022a6e",
-                      }}
+                      className="px-1.5 py-0.5 font-mono font-bold bg-chrome-green text-chrome-blue-dark border border-chrome-blue-dark"
+                      style={{ fontSize: 9 }}
                     >
                       {unreadCount} novo{unreadCount > 1 ? "s" : ""}
                     </span>
@@ -362,14 +328,11 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
                 </div>
                 <button
                   onClick={markAllRead}
+                  className="font-mono text-chrome-blue-content underline cursor-pointer"
                   style={{
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: 9,
-                    color: "#c8e0ff",
                     background: "transparent",
                     border: "none",
-                    cursor: "pointer",
-                    textDecoration: "underline",
                     letterSpacing: "0.05em",
                   }}
                 >
@@ -420,42 +383,31 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <span
+                          className="font-mono uppercase"
                           style={{
-                            fontFamily: "'Space Mono', monospace",
                             fontSize: 10,
                             color: n.unread ? "#e0eeff" : "#c8e0ff",
                             fontWeight: n.unread ? 700 : 400,
                             letterSpacing: "0.04em",
-                            textTransform: "uppercase",
                           }}
                         >
                           {n.title}
                         </span>
                         {n.unread && (
                           <span
-                            className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                            style={{ background: "#4ade80" }}
+                            className="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-chrome-green"
                           />
                         )}
                       </div>
                       <p
-                        className="mt-0.5 truncate"
-                        style={{
-                          fontFamily: "'Space Grotesk', sans-serif",
-                          fontSize: 11,
-                          color: "#a0c0f0",
-                          lineHeight: 1.4,
-                        }}
+                        className="mt-0.5 truncate font-grotesk"
+                        style={{ fontSize: 11, color: "#a0c0f0", lineHeight: 1.4 }}
                       >
                         {n.body}
                       </p>
                       <span
-                        style={{
-                          fontFamily: "'Space Mono', monospace",
-                          fontSize: 9,
-                          color: "rgba(128,176,255,0.55)",
-                          letterSpacing: "0.06em",
-                        }}
+                        className="font-mono"
+                        style={{ fontSize: 9, color: "rgba(128,176,255,0.55)", letterSpacing: "0.06em" }}
                       >
                         {n.time}
                       </span>
@@ -474,16 +426,12 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
                     markAllRead();
                     setNotifOpen(false);
                   }}
+                  className="font-mono text-chrome-blue-content uppercase underline cursor-pointer"
                   style={{
-                    fontFamily: "'Space Mono', monospace",
                     fontSize: 10,
-                    color: "#c8e0ff",
                     background: "transparent",
                     border: "none",
-                    cursor: "pointer",
                     letterSpacing: "0.1em",
-                    textTransform: "uppercase",
-                    textDecoration: "underline",
                   }}
                 >
                   marcar lidas e fechar →
@@ -495,7 +443,7 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
 
         {/* User avatars */}
         <div className="flex items-center gap-1 sm:gap-2">
-          <div className="w-9 h-9 overflow-hidden relative" style={{ border: "2px solid #80b0ff" }}>
+          <div className="w-9 h-9 overflow-hidden relative border-2 border-chrome-blue-soft">
             <Image
               src="https://images.unsplash.com/photo-1563669528538-1f3d1d08791b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwb3J0cmFpdCUyMHdvbWFuJTIwY3JlYXRpdmUlMjBjb2xvcmZ1bHxlbnwxfHx8fDE3NzI4MzI1MDh8MA&ixlib=rb-4.1.0&q=80&w=1080"
               alt="Profile"
@@ -505,8 +453,7 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
             />
           </div>
           <div
-            className="hidden sm:block w-9 h-9 overflow-hidden rounded-full relative"
-            style={{ border: "2px solid #4ade80" }}
+            className="hidden sm:block w-9 h-9 overflow-hidden rounded-full relative border-2 border-chrome-green"
           >
             <Image
               src="https://images.unsplash.com/photo-1753176185106-eba130fdc775?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwb3J0cmFpdCUyMG1hbiUyMGFydGlzdGljJTIwc3R1ZGlvfGVufDF8fHx8MTc3MjgzMjUwOHww&ixlib=rb-4.1.0&q=80&w=1080"

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -102,42 +102,32 @@ export function Sidebar({
 
       {/* Title bar */}
       <div
-        className="flex items-center justify-between px-3 py-1.5 flex-shrink-0"
-        style={{ backgroundColor: "#0458d4", borderBottom: "2px solid #022a6e", minHeight: "28px" }}
+        className="flex items-center justify-between px-3 py-1.5 flex-shrink-0 bg-chrome-blue-mid"
+        style={{ borderBottom: "2px solid #022a6e", minHeight: "28px" }}
       >
         {isExpanded ? (
           <span
-            style={{
-              fontFamily: "'Space Mono', monospace",
-              fontSize: "10px",
-              fontWeight: 700,
-              color: "#c8e0ff",
-              letterSpacing: "0.05em",
-              whiteSpace: "nowrap",
-            }}
+            className="font-mono font-bold text-chrome-blue-content whitespace-nowrap"
+            style={{ fontSize: "10px", letterSpacing: "0.05em" }}
           >
             NAVIGATION.EXE
           </span>
         ) : (
           <span
-            style={{
-              fontFamily: "'Space Mono', monospace",
-              fontSize: "10px",
-              fontWeight: 700,
-              color: "#c8e0ff",
-            }}
+            className="font-mono font-bold text-chrome-blue-content"
+            style={{ fontSize: "10px" }}
           >
             NAV
           </span>
         )}
         <div className="flex items-center gap-1 flex-shrink-0">
           <div
-            className="w-3 h-3"
-            style={{ border: "1.5px solid #0560e0", backgroundColor: "#0347c1" }}
+            className="w-3 h-3 bg-chrome-blue"
+            style={{ border: "1.5px solid #0560e0" }}
           />
           <div
-            className="w-3 h-3"
-            style={{ border: "1.5px solid #0560e0", backgroundColor: "#e05050" }}
+            className="w-3 h-3 bg-chrome-red"
+            style={{ border: "1.5px solid #0560e0" }}
           />
         </div>
       </div>
@@ -153,8 +143,8 @@ export function Sidebar({
             style={{ justifyContent: isExpanded ? "flex-start" : "center" }}
           >
             <div
-              className="w-10 h-10 flex items-center justify-center flex-shrink-0 overflow-hidden"
-              style={{ border: "3px solid #80b0ff", backgroundColor: "#0458d4" }}
+              className="w-10 h-10 flex items-center justify-center flex-shrink-0 overflow-hidden bg-chrome-blue-mid"
+              style={{ border: "3px solid #80b0ff" }}
             >
               {/* Replace /avatar-pixel-art.png with the extracted Figma asset */}
               <Image
@@ -167,13 +157,10 @@ export function Sidebar({
             </div>
             {isExpanded && (
               <span
-                style={{
-                  fontFamily: "'Rubik Glitch', sans-serif",
-                  fontWeight: 700,
+                className="font-glitch font-bold text-white whitespace-nowrap"
+              style={{
                   fontSize: "22px",
                   letterSpacing: "-0.02em",
-                  color: "#fff",
-                  whiteSpace: "nowrap",
                   opacity: isExpanded ? 1 : 0,
                   transition: "opacity 0.2s ease",
                 }}
@@ -306,20 +293,15 @@ export function Sidebar({
               </svg>
               <div className="mb-4 px-1">
                 <div
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "9px",
-                    color: "#4ade80",
-                    marginBottom: "2px",
-                  }}
+                  className="font-mono text-chrome-green"
+                  style={{ fontSize: "9px", marginBottom: "2px" }}
                 >
                   LOADING...
                 </div>
                 <div
-                  className="h-3 w-full"
-                  style={{ border: "2px solid #0560e0", backgroundColor: "#022a6e" }}
+                  className="h-3 w-full border-2 border-chrome-blue-accent bg-chrome-blue-dark"
                 >
-                  <div className="h-full" style={{ width: "72%", backgroundColor: "#4ade80" }} />
+                  <div className="h-full bg-chrome-green" style={{ width: "72%" }} />
                 </div>
               </div>
             </>

--- a/components/layout/newsletter/NewsletterModal.tsx
+++ b/components/layout/newsletter/NewsletterModal.tsx
@@ -96,11 +96,8 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
             >
               {/* Title bar */}
               <div
-                className="flex items-center justify-between px-3 py-2"
-                style={{
-                  backgroundColor: "#0458d4",
-                  borderBottom: "2px solid #022a6e",
-                }}
+                className="flex items-center justify-between px-3 py-2 bg-chrome-blue-mid"
+                style={{ borderBottom: "2px solid #022a6e" }}
               >
                 <div className="flex items-center gap-2">
                   <motion.div
@@ -114,32 +111,20 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                     <Bell size={12} style={{ color: "#4ade80" }} />
                   </motion.div>
                   <span
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "10px",
-                      fontWeight: 700,
-                      color: "#c8e0ff",
-                      letterSpacing: "0.05em",
-                    }}
+                    className="font-mono font-bold text-chrome-blue-content"
+                    style={{ fontSize: "10px", letterSpacing: "0.05em" }}
                   >
                     NOTIFY.EXE
                   </span>
                 </div>
                 <div className="flex items-center gap-1.5">
                   <div
-                    className="w-3 h-3"
-                    style={{
-                      border: "1.5px solid #022a6e",
-                      backgroundColor: "#0347c1",
-                    }}
+                    className="w-3 h-3 bg-chrome-blue"
+                    style={{ border: "1.5px solid #022a6e" }}
                   />
                   <motion.button
-                    className="w-3 h-3 flex items-center justify-center cursor-pointer"
-                    style={{
-                      border: "1.5px solid #022a6e",
-                      backgroundColor: "#e05050",
-                      padding: 0,
-                    }}
+                    className="w-3 h-3 flex items-center justify-center cursor-pointer bg-chrome-red"
+                    style={{ border: "1.5px solid #022a6e", padding: 0 }}
                     whileHover={{ scale: 1.2 }}
                     whileTap={{ scale: 0.9 }}
                     onClick={onClose}
@@ -151,7 +136,7 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
               </div>
 
               {/* Body */}
-              <div className="relative overflow-hidden" style={{ backgroundColor: "#0347c1" }}>
+              <div className="relative overflow-hidden bg-chrome-blue">
                 {/* Pulsing glow */}
                 <motion.div
                   className="absolute pointer-events-none"
@@ -212,24 +197,14 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           </motion.div>
                           <div>
                             <span
-                              style={{
-                                fontFamily: "'Space Grotesk', sans-serif",
-                                fontWeight: 700,
-                                fontSize: "18px",
-                                color: "#fff",
-                                display: "block",
-                                lineHeight: 1.2,
-                              }}
+                              className="font-grotesk font-bold text-white block"
+                              style={{ fontSize: "18px", lineHeight: 1.2 }}
                             >
                               Fique por dentro!
                             </span>
                             <span
-                              style={{
-                                fontFamily: "'Space Mono', monospace",
-                                fontSize: "9px",
-                                color: "#4ade80",
-                                letterSpacing: "0.05em",
-                              }}
+                              className="font-mono text-chrome-green"
+                              style={{ fontSize: "9px", letterSpacing: "0.05em" }}
                             >
                               TRANSMISSAO ATIVA
                             </span>
@@ -237,13 +212,8 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                         </div>
 
                         <p
-                          className="mt-3 mb-5"
-                          style={{
-                            fontFamily: "'Space Grotesk', sans-serif",
-                            fontSize: "14px",
-                            lineHeight: 1.65,
-                            color: "#a0c4ff",
-                          }}
+                          className="mt-3 mb-5 font-grotesk text-chrome-blue-body"
+                          style={{ fontSize: "14px", lineHeight: 1.65 }}
                         >
                           Receba um aviso no e-mail sempre que sair post novo. Nada de conteudo
                           exclusivo — tudo esta aqui, aberto, no blog.
@@ -263,16 +233,11 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                               onChange={(e) => { setEmail(e.target.value); if (error) setError(""); }}
                               placeholder="seu@email.com"
                               autoFocus
-                              className="w-full pl-9 pr-4 py-3"
+                              className="w-full pl-9 pr-4 py-3 font-mono text-white bg-chrome-blue-dark border-2 border-chrome-blue-accent outline-none"
                               aria-invalid={!!error}
                               aria-describedby={error ? "modal-email-error" : undefined}
                               style={{
-                                backgroundColor: "#022a6e",
-                                border: "2px solid #0560e0",
-                                color: "#fff",
-                                fontFamily: "'Space Mono', monospace",
                                 fontSize: "12px",
-                                outline: "none",
                                 transition: "border-color 0.2s, box-shadow 0.2s",
                               }}
                               onFocus={(e) => {
@@ -294,12 +259,8 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                                 animate={{ opacity: 1, y: 0 }}
                                 exit={{ opacity: 0, y: -4 }}
                                 transition={{ duration: 0.2 }}
-                                className="mb-3 -mt-1"
-                                style={{
-                                  fontFamily: "'Space Mono', monospace",
-                                  fontSize: "9px",
-                                  color: "#ff6b6b",
-                                }}
+                                className="mb-3 -mt-1 font-mono"
+                                style={{ fontSize: "9px", color: "#ff6b6b" }}
                               >
                                 {error}
                               </motion.p>
@@ -309,16 +270,11 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           {/* Submit button */}
                           <motion.button
                             type="submit"
-                            className="w-full flex items-center justify-center gap-2 px-5 py-3"
+                            className="w-full flex items-center justify-center gap-2 px-5 py-3 font-mono font-bold bg-chrome-green text-chrome-blue-dark cursor-pointer"
                             style={{
                               border: "3px solid #022a6e",
-                              backgroundColor: "#4ade80",
                               boxShadow: "4px 4px 0 #022a6e",
-                              fontFamily: "'Space Mono', monospace",
                               fontSize: "11px",
-                              fontWeight: 700,
-                              color: "#022a6e",
-                              cursor: "pointer",
                             }}
                             whileHover={{
                               x: -2,
@@ -349,38 +305,22 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
 
                         {/* Privacy notice */}
                         <div
-                          className="mt-4 p-3 flex gap-2.5"
-                          style={{
-                            backgroundColor: "#022a6e",
-                            border: "1px solid #0560e0",
-                          }}
+                          className="mt-4 p-3 flex gap-2.5 bg-chrome-blue-dark border border-chrome-blue-accent"
                         >
                           <Lock
                             size={13}
-                            className="flex-shrink-0 mt-0.5"
-                            style={{ color: "#a0c4ff" }}
+                            className="flex-shrink-0 mt-0.5 text-chrome-blue-body"
                           />
                           <div>
                             <span
-                              style={{
-                                fontFamily: "'Space Mono', monospace",
-                                fontSize: "9px",
-                                fontWeight: 700,
-                                color: "#c8e0ff",
-                                letterSpacing: "0.03em",
-                                display: "block",
-                                marginBottom: "3px",
-                              }}
+                              className="font-mono font-bold text-chrome-blue-content block"
+                              style={{ fontSize: "9px", letterSpacing: "0.03em", marginBottom: "3px" }}
                             >
                               PRIVACIDADE
                             </span>
                             <p
-                              style={{
-                                fontFamily: "'Space Mono', monospace",
-                                fontSize: "9px",
-                                lineHeight: 1.6,
-                                color: "#a0c4ff",
-                              }}
+                              className="font-mono text-chrome-blue-body"
+                              style={{ fontSize: "9px", lineHeight: 1.6 }}
                             >
                               Nao armazeno nenhuma informacao pessoal dos visitantes deste site. Seu
                               e-mail sera usado apenas para enviar notificacoes de novos posts e
@@ -422,13 +362,8 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           initial={{ opacity: 0, y: 10 }}
                           animate={{ opacity: 1, y: 0 }}
                           transition={{ delay: 0.3 }}
-                          style={{
-                            fontFamily: "'Space Grotesk', sans-serif",
-                            fontWeight: 700,
-                            fontSize: "20px",
-                            color: "#4ade80",
-                            display: "block",
-                          }}
+                          className="font-grotesk font-bold text-chrome-green block"
+                          style={{ fontSize: "20px" }}
                         >
                           Tudo certo!
                         </motion.span>
@@ -437,13 +372,8 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           initial={{ opacity: 0, y: 10 }}
                           animate={{ opacity: 1, y: 0 }}
                           transition={{ delay: 0.4 }}
-                          className="mt-2 max-w-[320px]"
-                          style={{
-                            fontFamily: "'Space Grotesk', sans-serif",
-                            fontSize: "14px",
-                            lineHeight: 1.6,
-                            color: "#a0c4ff",
-                          }}
+                          className="mt-2 max-w-[320px] font-grotesk text-chrome-blue-body"
+                          style={{ fontSize: "14px", lineHeight: 1.6 }}
                         >
                           Voce vai receber um aviso sempre que eu publicar algo novo. Fique de olho
                           na caixa de entrada!
@@ -454,14 +384,8 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           initial={{ opacity: 0 }}
                           animate={{ opacity: 1 }}
                           transition={{ delay: 0.55 }}
-                          className="mt-4 px-4 py-2"
-                          style={{
-                            backgroundColor: "#022a6e",
-                            border: "2px solid #0560e0",
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "10px",
-                            color: "#4ade80",
-                          }}
+                          className="mt-4 px-4 py-2 font-mono text-chrome-green bg-chrome-blue-dark border-2 border-chrome-blue-accent"
+                          style={{ fontSize: "10px" }}
                         >
                           {">"} NOTIFY_ID: #{notifyId}
                         </motion.div>
@@ -473,13 +397,10 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           transition={{ delay: 0.65 }}
                           className="mt-4 flex items-center gap-1.5"
                         >
-                          <ShieldCheck size={12} style={{ color: "#a0c4ff" }} />
+                          <ShieldCheck size={12} className="text-chrome-blue-body" />
                           <span
-                            style={{
-                              fontFamily: "'Space Mono', monospace",
-                              fontSize: "8px",
-                              color: "#a0c4ff",
-                            }}
+                            className="font-mono text-chrome-blue-body"
+                            style={{ fontSize: "8px" }}
                           >
                             NENHUMA INFORMACAO PESSOAL ARMAZENADA
                           </span>
@@ -490,15 +411,8 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           initial={{ opacity: 0 }}
                           animate={{ opacity: 1 }}
                           transition={{ delay: 0.75 }}
-                          className="mt-5 px-5 py-2 cursor-pointer"
-                          style={{
-                            border: "2px solid #0560e0",
-                            backgroundColor: "#0458d4",
-                            fontFamily: "'Space Mono', monospace",
-                            fontSize: "10px",
-                            fontWeight: 700,
-                            color: "#c8e0ff",
-                          }}
+                          className="mt-5 px-5 py-2 cursor-pointer font-mono font-bold bg-chrome-blue-mid text-chrome-blue-content border-2 border-chrome-blue-accent"
+                          style={{ fontSize: "10px" }}
                           whileHover={{
                             backgroundColor: "#0560e0",
                             color: "#fff",

--- a/components/layout/newsletter/NewsletterWidget.tsx
+++ b/components/layout/newsletter/NewsletterWidget.tsx
@@ -63,11 +63,8 @@ export function NewsletterWidget() {
                 {/* Header */}
                 <div className="flex items-start gap-3 mb-3">
                   <motion.div
-                    className="flex-shrink-0 w-9 h-9 flex items-center justify-center mt-0.5"
-                    style={{
-                      border: "2px solid #4ade80",
-                      backgroundColor: "#4ade8015",
-                    }}
+                    className="flex-shrink-0 w-9 h-9 flex items-center justify-center mt-0.5 border-2 border-chrome-green text-chrome-green"
+                    style={{ backgroundColor: "#4ade8015" }}
                     animate={{ rotate: [0, 8, -8, 0] }}
                     transition={{
                       duration: 2.5,
@@ -75,30 +72,19 @@ export function NewsletterWidget() {
                       repeatDelay: 4,
                     }}
                   >
-                    <Bell size={16} style={{ color: "#4ade80" }} />
+                    <Bell size={16} />
                   </motion.div>
 
                   <div>
                     <span
-                      style={{
-                        fontFamily: "'Space Grotesk', sans-serif",
-                        fontWeight: 700,
-                        fontSize: "clamp(14px, 2.5vw, 17px)",
-                        color: "#fff",
-                        display: "block",
-                        lineHeight: 1.25,
-                      }}
+                      className="font-grotesk font-bold text-white block"
+                      style={{ fontSize: "clamp(14px, 2.5vw, 17px)", lineHeight: 1.25 }}
                     >
                       Quer receber os novos posts no seu e-mail?
                     </span>
                     <p
-                      className="mt-1"
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "10px",
-                        lineHeight: 1.55,
-                        color: "#a0c4ff",
-                      }}
+                      className="mt-1 font-mono text-chrome-blue-body"
+                      style={{ fontSize: "10px", lineHeight: 1.55 }}
                     >
                       Sem spam, sem conteudo premium — so um aviso quando sair post novo.
                     </p>
@@ -118,16 +104,11 @@ export function NewsletterWidget() {
                       value={email}
                       onChange={(e) => { setEmail(e.target.value); if (error) setError(""); }}
                       placeholder="seu@email.com"
-                      className="w-full pl-8 pr-3 py-2.5"
+                      className="w-full pl-8 pr-3 py-2.5 font-mono text-white bg-chrome-blue-dark border-2 border-chrome-blue-accent outline-none"
                       aria-invalid={!!error}
                       aria-describedby={error ? "widget-email-error" : undefined}
                       style={{
-                        backgroundColor: "#022a6e",
-                        border: "2px solid #0560e0",
-                        color: "#fff",
-                        fontFamily: "'Space Mono', monospace",
                         fontSize: "11px",
-                        outline: "none",
                         transition: "border-color 0.2s, box-shadow 0.2s",
                       }}
                       onFocus={(e) => {
@@ -143,16 +124,11 @@ export function NewsletterWidget() {
 
                   <motion.button
                     type="submit"
-                    className="flex items-center justify-center gap-2 px-5 py-2.5"
+                    className="flex items-center justify-center gap-2 px-5 py-2.5 font-mono font-bold bg-chrome-green text-chrome-blue-dark cursor-pointer"
                     style={{
                       border: "3px solid #022a6e",
-                      backgroundColor: "#4ade80",
                       boxShadow: "4px 4px 0 #022a6e",
-                      fontFamily: "'Space Mono', monospace",
                       fontSize: "10px",
-                      fontWeight: 700,
-                      color: "#022a6e",
-                      cursor: "pointer",
                       flexShrink: 0,
                     }}
                     whileHover={{
@@ -187,12 +163,8 @@ export function NewsletterWidget() {
                       animate={{ opacity: 1, y: 0 }}
                       exit={{ opacity: 0, y: -4 }}
                       transition={{ duration: 0.2 }}
-                      className="mt-1.5"
-                      style={{
-                        fontFamily: "'Space Mono', monospace",
-                        fontSize: "9px",
-                        color: "#ff6b6b",
-                      }}
+                      className="mt-1.5 font-mono"
+                      style={{ fontSize: "9px", color: "#ff6b6b" }}
                     >
                       {error}
                     </motion.p>
@@ -200,12 +172,8 @@ export function NewsletterWidget() {
                 </AnimatePresence>
 
                 <p
-                  className="mt-2"
-                  style={{
-                    fontFamily: "'Space Mono', monospace",
-                    fontSize: "8px",
-                    color: "#3a6aaa",
-                  }}
+                  className="mt-2 font-mono text-chrome-blue-dim"
+                  style={{ fontSize: "8px" }}
                 >
                   * Cancele quando quiser. Nada de conteudo exclusivo — tudo esta aqui no blog.
                 </p>
@@ -227,28 +195,19 @@ export function NewsletterWidget() {
                     delay: 0.15,
                   }}
                 >
-                  <CheckCircle size={28} style={{ color: "#4ade80" }} />
+                  <CheckCircle size={28} className="text-chrome-green" />
                 </motion.div>
 
                 <div>
                   <span
-                    style={{
-                      fontFamily: "'Space Grotesk', sans-serif",
-                      fontWeight: 700,
-                      fontSize: "14px",
-                      color: "#4ade80",
-                      display: "block",
-                    }}
+                    className="font-grotesk font-bold text-chrome-green block"
+                    style={{ fontSize: "14px" }}
                   >
                     Pronto! Voce vai saber quando sair post novo.
                   </span>
                   <p
-                    className="mt-0.5"
-                    style={{
-                      fontFamily: "'Space Mono', monospace",
-                      fontSize: "9px",
-                      color: "#a0c4ff",
-                    }}
+                    className="mt-0.5 font-mono text-chrome-blue-body"
+                    style={{ fontSize: "9px" }}
                   >
                     ID: #{notifyId} — confira sua caixa de entrada.
                   </p>

--- a/components/ui/CategoryHero.tsx
+++ b/components/ui/CategoryHero.tsx
@@ -146,7 +146,7 @@ export function CategoryHero({
                   {crumb.to ? (
                     <Link
                       href={crumb.to}
-                      className="inline-flex items-center gap-1.5 px-3 py-1.5"
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 font-mono font-bold"
                       style={{
                         background: "rgba(255,255,255,0.1)",
                         backdropFilter: "blur(12px)",
@@ -154,9 +154,7 @@ export function CategoryHero({
                           ? `2px solid ${accentColor}66`
                           : "2px solid rgba(255,255,255,0.2)",
                         color: crumb.active ? accentColor : "#fff",
-                        fontFamily: "'Space Mono', monospace",
                         fontSize: "10px",
-                        fontWeight: 700,
                         textDecoration: "none",
                       }}
                     >
@@ -165,17 +163,14 @@ export function CategoryHero({
                     </Link>
                   ) : (
                     <span
-                      className="px-3 py-1.5"
+                      className="px-3 py-1.5 font-mono font-bold text-white"
                       style={{
                         background: crumb.active ? `${accentColor}22` : "rgba(255,255,255,0.1)",
                         backdropFilter: "blur(12px)",
                         border: crumb.active
                           ? `2px solid ${accentColor}66`
                           : "2px solid rgba(255,255,255,0.2)",
-                        color: "#fff",
-                        fontFamily: "'Space Mono', monospace",
                         fontSize: "10px",
-                        fontWeight: 700,
                       }}
                     >
                       {crumb.label}
@@ -187,15 +182,12 @@ export function CategoryHero({
           ) : (
             <Link
               href="/"
-              className="inline-flex items-center gap-2 px-3 py-1.5 mb-4"
+              className="inline-flex items-center gap-2 px-3 py-1.5 mb-4 font-mono font-bold text-white"
               style={{
                 background: "rgba(255,255,255,0.12)",
                 backdropFilter: "blur(12px)",
                 border: "2px solid rgba(255,255,255,0.25)",
-                color: "#fff",
-                fontFamily: "'Space Mono', monospace",
                 fontSize: "10px",
-                fontWeight: 700,
                 textDecoration: "none",
               }}
             >
@@ -205,8 +197,8 @@ export function CategoryHero({
           )}
 
           <div
+            className="font-mono"
             style={{
-              fontFamily: "'Space Mono', monospace",
               fontSize: "10px",
               color: accentColor,
               marginBottom: "6px",
@@ -226,9 +218,8 @@ export function CategoryHero({
           />
 
           <p
-            className="mt-3 max-w-[600px]"
+            className="mt-3 max-w-[600px] font-grotesk"
             style={{
-              fontFamily: "'Space Grotesk', sans-serif",
               fontSize: "15px",
               lineHeight: 1.6,
               color: "rgba(255,255,255,0.75)",

--- a/components/ui/RetroWindow.tsx
+++ b/components/ui/RetroWindow.tsx
@@ -58,13 +58,11 @@ export function RetroWindow({
         }}
       >
         <span
+          className="font-mono font-bold uppercase"
           style={{
-            fontFamily: "'Space Mono', monospace",
             fontSize: "11px",
-            fontWeight: 700,
             color: titleText,
             letterSpacing: "0.05em",
-            textTransform: "uppercase",
           }}
         >
           {title}
@@ -87,14 +85,11 @@ export function RetroWindow({
           )}
           {onClose && (
             <button
-              className="w-4 h-4 flex items-center justify-center"
+              className="w-4 h-4 flex items-center justify-center bg-chrome-red text-white font-bold"
               style={{
                 border: `2px solid ${borderColor}`,
-                backgroundColor: "#e05050",
                 fontSize: "10px",
-                fontWeight: 700,
                 lineHeight: 1,
-                color: "#fff",
               }}
             >
               x

--- a/components/ui/WavyText.tsx
+++ b/components/ui/WavyText.tsx
@@ -30,8 +30,7 @@ export function WavyText({
     const cssSize = typeof fontSize === "number" ? `${fontSize}px` : fontSize;
     return (
       <div
-        className={`relative overflow-hidden ${className}`}
-        style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+        className={`relative overflow-hidden font-grotesk ${className}`}
       >
         {[0, 1, 2].map((i) => (
           <div

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -224,19 +224,76 @@ background: radial-gradient(circle at 35% 35%, rgba(255,255,255,0.2), rgba(128,1
 filter: blur(8px);
 ```
 
+## Token Architecture (Single Source of Truth)
+
+All color values live in **one file only**: `styles/theme.css`. Components never contain raw hex strings.
+
+### Three-Layer System
+
+| Layer | File | Purpose |
+|---|---|---|
+| CSS custom properties | `styles/theme.css` `:root` | Raw values — the only place hex is written |
+| Tailwind utility classes | `styles/theme.css` `@theme inline` | Maps vars to `bg-*`, `text-*`, `border-*`, `font-*` |
+| TypeScript constants | `lib/design-tokens.ts` / `constants/posts.ts` | Dynamic values CSS can't handle (font strings, `categoryColors`) |
+
+### Two Color Namespaces
+
+**`arm-*` — Theme-responsive** (changes in dark mode):
+- `bg-arm-bg` — page background
+- `text-arm-text` — primary text
+- `border-arm-border` — general borders
+- `bg-arm-panel-bg` — dark panel interiors (inside RetroWindow dark)
+- `text-arm-panel-text-body` — body text inside dark panels
+
+**`chrome-*` — Static chrome** (never changes — sidebar/header are always the same blue):
+- `bg-chrome-blue` → `#0347c1` sidebar bg
+- `bg-chrome-blue-mid` → `#0458d4` panel interior
+- `border-chrome-blue-accent` → `#0560e0` panel borders
+- `text-chrome-blue-body` → `#a0c4ff` secondary text on dark
+- `text-chrome-blue-text-on-dark` → `#c8e0ff` content text on dark
+- `text-chrome-green` → `#4ade80` active indicators, NowPlaying
+- `text-chrome-red` → `#e05050` close buttons, errors
+- `text-chrome-purple` → `#c084fc` Filosofia accent
+- `text-chrome-amber` → `#f59e0b` Músicas accent
+
+### Font Utility Classes
+
+Registered in `@theme inline`:
+
+| Class | Font | Usage |
+|---|---|---|
+| `font-mono` | Space Mono | Labels, metadata, terminal text, timestamps |
+| `font-grotesk` | Space Grotesk | Headings, titles, body text |
+| `font-glitch` | Rubik Glitch | Sidebar logo only |
+| `font-bungee` | Bungee Shade | Footer "ARMANDO" branding only |
+
+### Decision Rule
+
+| Situation | Use |
+|---|---|
+| Static color → matches a token | Tailwind class: `className="bg-chrome-blue"` |
+| Static font family | Tailwind class: `className="font-mono"` |
+| Dynamic color (e.g. `categoryColors[post.category]`) | `style={{ color: categoryColors[x] }}` |
+| Complex box-shadow / gradient | `style={{}}` with `var(--chrome-*)` refs inside |
+| Conditional color ternary | `style={{ color: isActive ? "var(--chrome-green)" : "var(--chrome-blue-body)" }}` |
+
+See `docs/learnings/design-system-tokens.md` for the full rationale.
+
+---
+
 ## Tailwind Usage
 
 The project uses **Tailwind CSS v4** (not v3). Key differences:
 - No `tailwind.config.js` file
-- Theme tokens defined via `@theme inline` in `theme.css`
+- All design tokens (colors, fonts) defined via `@theme inline` in `styles/theme.css`
 - Custom variants: `@custom-variant dark (&:is([data-theme="dark"] *))` — NOT `.dark` (see PITFALL-003)
 - Uses `@layer base` for element defaults
 
-Most styling is done via **inline `style` props**, not Tailwind classes. Tailwind is used mainly for:
-- Layout: `flex`, `grid`, `items-center`, `gap-*`, `px-*`, `py-*`
-- Responsive: `sm:`, `md:`, `lg:`, `xl:` breakpoints
-- Sizing: `w-full`, `h-screen`, `flex-1`, `min-w-0`
-- Utilities: `overflow-hidden`, `truncate`, `line-clamp-*`, `pointer-events-none`
-- Transitions: `transition-all`, `duration-*`
+Tailwind is used for:
+- **Design tokens**: `bg-arm-bg`, `text-chrome-blue-body`, `border-arm-border`, `font-mono`, etc.
+- **Layout**: `flex`, `grid`, `items-center`, `gap-*`, `px-*`, `py-*`
+- **Responsive**: `sm:`, `md:`, `lg:`, `xl:` breakpoints
+- **Sizing**: `w-full`, `h-screen`, `flex-1`, `min-w-0`
+- **Utilities**: `overflow-hidden`, `truncate`, `line-clamp-*`, `pointer-events-none`
 
-Font sizes, font weights, colors, borders, and shadows are almost always inline `style` props — NOT Tailwind classes. This is intentional for the custom design system.
+`style={{}}` is reserved for: complex box-shadows, multi-value gradients, `clamp()` font sizes, and computed dynamic values.

--- a/docs/learnings/design-system-tokens.md
+++ b/docs/learnings/design-system-tokens.md
@@ -1,0 +1,137 @@
+# Design System Tokens — Learnings
+
+## The Problem We Solved
+
+The blog started with ~600 hardcoded hex values like `#0347c1`, `#022a6e`, `#a0c4ff` scattered across 25+ component files. Changing one color meant grep-replacing every file. Adding dark mode required touching every component. There was no way to look at one file and understand what colors existed in the system.
+
+## The Solution: Three-Layer Token Architecture
+
+### Layer 1 — CSS Custom Properties (the only place raw hex lives)
+
+```css
+/* styles/theme.css */
+:root {
+  --arm-bg: #f5f0e3;       /* theme-responsive: changes in dark mode */
+  --chrome-blue: #0347c1;  /* static: never changes, structural chrome */
+}
+
+[data-theme="dark"] {
+  --arm-bg: #0c0b14;       /* only --arm-* vars are overridden here */
+}
+```
+
+**Why CSS vars?** The browser resolves them at paint time. When the dark mode attribute flips, every element using `var(--arm-bg)` updates automatically — zero JS involved.
+
+### Layer 2 — Tailwind `@theme inline` (maps CSS vars to utility classes)
+
+```css
+/* styles/theme.css */
+@theme inline {
+  --color-arm-bg: var(--arm-bg);           /* generates bg-arm-bg, text-arm-bg, border-arm-bg */
+  --color-chrome-blue: var(--chrome-blue); /* generates bg-chrome-blue, text-chrome-blue, etc. */
+  --font-mono: 'Space Mono', monospace;    /* generates font-mono class */
+}
+```
+
+**Why `@theme inline`?** Tailwind v4 replaced `tailwind.config.js` with this CSS-native approach. Tokens declared here become utility classes automatically. The `inline` keyword means "resolve the variable immediately, don't lazy-compute it" — important for values that change with the cascade (like CSS vars pointing to `:root`).
+
+**What v3 looked like (for comparison):**
+```js
+// tailwind.config.js (v3 — NOT used in this project)
+module.exports = {
+  theme: {
+    extend: {
+      colors: { 'chrome-blue': '#0347c1' }
+    }
+  }
+}
+```
+Tailwind v4 eliminates this file entirely. All token configuration is in CSS.
+
+### Layer 3 — TypeScript Constants (for things CSS can't do)
+
+```ts
+// lib/design-tokens.ts
+export const FONT_MONO = "'Space Mono', monospace";
+
+// constants/posts.ts
+export const categoryColors: Record<string, string> = {
+  "Estudos": "#4ade80",
+  "Filmes":  "#e05050",
+};
+```
+
+**Why JS constants?** CSS vars can't do runtime key lookups. `categoryColors[post.category]` is a dynamic access — we get the color at runtime based on a string. CSS has no equivalent.
+
+Font family strings are also duplicated here because `style={{ fontFamily: FONT_MONO }}` is still needed in a few places where a Tailwind class isn't enough (e.g., inside `motion` component style props, or when the font is set conditionally).
+
+---
+
+## Two Token Namespaces
+
+### `--arm-*` — Theme-Responsive
+
+These change between light and dark mode. Use for page backgrounds, text colors, borders on content areas.
+
+```
+bg-arm-bg           → page background (cream light / dark night)
+text-arm-text       → primary text (#022a6e light / #e4ecf8 dark)
+border-arm-border   → general borders
+bg-arm-panel-bg     → dark panel interior (inside RetroWindow dark)
+text-arm-panel-text-body → body text inside dark panels
+```
+
+### `--chrome-*` — Static
+
+These never change between themes. The sidebar, header, and window chrome are the same blue regardless of light/dark mode — that's an intentional design decision.
+
+```
+bg-chrome-blue        → #0347c1 sidebar bg
+bg-chrome-blue-mid    → #0458d4 panel interior
+border-chrome-blue-accent → #0560e0 borders inside dark panels
+text-chrome-blue-body → #a0c4ff secondary text on dark surfaces
+text-chrome-green     → #4ade80 active/online indicators
+text-chrome-red       → #e05050 close buttons, errors
+```
+
+---
+
+## Decision Rule: When to Use What
+
+| Situation | Use |
+|---|---|
+| Static color, maps to a token | Tailwind class: `className="bg-chrome-blue"` |
+| Font family (static element) | Tailwind class: `className="font-mono"` |
+| Dynamic color (e.g. `categoryColors[x]`) | `style={{ color: categoryColors[x] }}` with import |
+| Complex box-shadow or gradient | `style={{}}` with `var(--chrome-*)` refs for any hex inside |
+| Conditional color ternary | `style={{ color: cond ? "var(--chrome-green)" : "var(--chrome-blue-accent)" }}` |
+
+The key insight: **Tailwind utility classes for anything static, CSS var references inside `style={{}}` for anything dynamic.**
+
+---
+
+## Why This Makes Dark Mode a Drop-In
+
+When dark mode is restored, only one block changes:
+
+```css
+[data-theme="dark"] {
+  --arm-bg: #0c0b14;
+  --arm-text: #e4ecf8;
+  /* ... override only the --arm-* vars ... */
+}
+```
+
+Every component using `bg-arm-bg`, `text-arm-text` etc. responds automatically. The chrome (`--chrome-*`) stays unchanged because it's structural — the sidebar is always blue. Only the content area adapts.
+
+**Zero component changes needed to restore dark mode** — that's the payoff of this architecture.
+
+---
+
+## Applying This in Future Projects
+
+1. **Define all raw colors in CSS `:root` first** — one file, one place.
+2. **Separate "theme-responsive" from "always-static" tokens** from the start. Name them differently (`--brand-*`, `--static-*`, or `--chrome-*`).
+3. **Register all tokens in your framework's theme system** — Tailwind `@theme`, Chakra theme, etc.
+4. **JS constants only for dynamic access** — if you're doing `colors[key]`, you need JS. If you're setting a fixed color, you don't.
+5. **Never hardcode hex in components** — the moment you do, you lose the single source of truth.

--- a/lib/design-tokens.ts
+++ b/lib/design-tokens.ts
@@ -1,0 +1,15 @@
+import type { CSSProperties } from "react";
+
+// Font family strings — use these in style={{ fontFamily }} for dynamic cases.
+// For static elements, prefer the Tailwind classes: font-mono, font-grotesk, font-glitch, font-bungee
+export const FONT_MONO = "'Space Mono', monospace";
+export const FONT_GROTESK = "'Space Grotesk', sans-serif";
+export const FONT_GLITCH = "'Rubik Glitch', sans-serif";
+export const FONT_BUNGEE = "'Bungee Shade', sans-serif";
+
+// Scanline overlay applied to card images throughout the blog.
+// Use as: <div className="absolute inset-0 pointer-events-none" style={scanlineStyle} />
+export const scanlineStyle: CSSProperties = {
+  backgroundImage:
+    "repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.1) 2px, rgba(0,0,0,0.1) 4px)",
+};

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -3,6 +3,22 @@
 /* @custom-variant dark (&:is([data-theme="dark"] *)); */
 
 :root {
+  /* ── Chrome (structural — never changes with theme) ── */
+  --chrome-blue: #0347c1;
+  --chrome-blue-mid: #0458d4;
+  --chrome-blue-accent: #0560e0;
+  --chrome-blue-dark: #022a6e;
+  --chrome-blue-soft: #80b0ff;
+  --chrome-blue-muted: #5a8ad0;
+  --chrome-blue-dim: #3a6aaa;
+  --chrome-blue-body: #a0c4ff;
+  --chrome-blue-content: #c0d8ff;
+  --chrome-blue-text-on-dark: #c8e0ff;
+  --chrome-green: #4ade80;
+  --chrome-red: #e05050;
+  --chrome-purple: #c084fc;
+  --chrome-amber: #f59e0b;
+
   /* ── Armando Blog Palette (Light) ── */
   --arm-bg: #f5f0e3;
   --arm-bg-card: #e8e4dc;
@@ -148,6 +164,56 @@
 /* DARK: } */
 
 @theme inline {
+  /* ── Armando font families ── */
+  --font-mono: 'Space Mono', monospace;
+  --font-grotesk: 'Space Grotesk', sans-serif;
+  --font-glitch: 'Rubik Glitch', sans-serif;
+  --font-bungee: 'Bungee Shade', sans-serif;
+
+  /* ── ARM theme-responsive colors ── */
+  --color-arm-bg: var(--arm-bg);
+  --color-arm-bg-card: var(--arm-bg-card);
+  --color-arm-bg-card-title: var(--arm-bg-card-title);
+  --color-arm-bg-glass: var(--arm-bg-glass);
+  --color-arm-border: var(--arm-border);
+  --color-arm-text: var(--arm-text);
+  --color-arm-text-secondary: var(--arm-text-secondary);
+  --color-arm-text-muted: var(--arm-text-muted);
+  --color-arm-blue: var(--arm-blue);
+  --color-arm-blue-mid: var(--arm-blue-mid);
+  --color-arm-blue-dark: var(--arm-blue-dark);
+  --color-arm-shadow: var(--arm-shadow);
+  --color-arm-grid: var(--arm-grid);
+
+  /* ── ARM panel colors (theme-responsive) ── */
+  --color-arm-panel-bg: var(--arm-panel-bg);
+  --color-arm-panel-bg-darker: var(--arm-panel-bg-darker);
+  --color-arm-panel-border: var(--arm-panel-border);
+  --color-arm-panel-bg-deep: var(--arm-panel-bg-deep);
+  --color-arm-panel-text: var(--arm-panel-text);
+  --color-arm-panel-text-soft: var(--arm-panel-text-soft);
+  --color-arm-panel-text-muted: var(--arm-panel-text-muted);
+  --color-arm-panel-text-dim: var(--arm-panel-text-dim);
+  --color-arm-panel-text-body: var(--arm-panel-text-body);
+  --color-arm-panel-text-content: var(--arm-panel-text-content);
+
+  /* ── Chrome static colors ── */
+  --color-chrome-blue: var(--chrome-blue);
+  --color-chrome-blue-mid: var(--chrome-blue-mid);
+  --color-chrome-blue-accent: var(--chrome-blue-accent);
+  --color-chrome-blue-dark: var(--chrome-blue-dark);
+  --color-chrome-blue-soft: var(--chrome-blue-soft);
+  --color-chrome-blue-muted: var(--chrome-blue-muted);
+  --color-chrome-blue-dim: var(--chrome-blue-dim);
+  --color-chrome-blue-body: var(--chrome-blue-body);
+  --color-chrome-blue-content: var(--chrome-blue-content);
+  --color-chrome-blue-text-on-dark: var(--chrome-blue-text-on-dark);
+  --color-chrome-green: var(--chrome-green);
+  --color-chrome-red: var(--chrome-red);
+  --color-chrome-purple: var(--chrome-purple);
+  --color-chrome-amber: var(--chrome-amber);
+
+  /* ── shadcn/ui tokens ── */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
## Summary

- **All raw hex values** moved to `styles/theme.css` as named CSS custom properties — the only place color values ever need to be written
- **`@theme inline` expanded** to register all `--arm-*` (theme-responsive) and `--chrome-*` (static chrome) tokens as Tailwind utility classes (`bg-chrome-blue`, `text-arm-panel-text-body`, `font-mono`, `font-grotesk`, etc.)
- **`lib/design-tokens.ts` created** for JS/TS constants that CSS can't handle: font family strings and the `scanlineStyle` pattern
- **27 component/page files migrated**: ~1,500 inline `style={{}}` occurrences replaced with token classes — net **-1,002 lines**
- **Dark mode is now a drop-in**: uncommenting the `[data-theme="dark"]` block in `theme.css` will make every `bg-arm-*` / `text-arm-*` utility respond automatically — zero component changes needed

## Docs updated

- `docs/DESIGN-SYSTEM.md` — full token architecture reference, decision rules table, utility class listing
- `docs/learnings/design-system-tokens.md` — new learning doc explaining the three-layer system, why CSS vars enable dark mode as a drop-in, and how to apply this in future projects

## What stays in `style={{}}`

Dynamic/computed colors (e.g. `categoryColors[post.category]`, `playlist.accentColor`), 3px neobrutalist borders, complex box-shadows, multi-value gradients, non-standard `fontSize`/`lineHeight` values, and the Spotify brand color `#1DB954`.

## Test plan

- [ ] Visual diff: all pages look pixel-identical to `main`
- [ ] `npm run lint` — zero errors ✅
- [ ] Check dark mode readiness: run `document.documentElement.setAttribute('data-theme', 'dark')` in DevTools — all `bg-arm-*` / `text-arm-*` utilities respond correctly