### PR TITLE
refactor: replace hardcoded hex values with CSS design tokens (issue #38)

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -63,11 +63,11 @@ export default function NotFound() {
   const buttonHover = {
     onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
       e.currentTarget.style.transform = "translate(-2px, -2px)";
-      e.currentTarget.style.boxShadow = "5px 5px 0 #022a6e";
+      e.currentTarget.style.boxShadow = "5px 5px 0 var(--arm-panel-bg-deep)";
     },
     onMouseLeave: (e: React.MouseEvent<HTMLElement>) => {
       e.currentTarget.style.transform = "translate(0, 0)";
-      e.currentTarget.style.boxShadow = "3px 3px 0 #022a6e";
+      e.currentTarget.style.boxShadow = "3px 3px 0 var(--arm-panel-bg-deep)";
     },
   };
 
@@ -203,13 +203,13 @@ export default function NotFound() {
                 text="PAGINA NAO ENCONTRADA"
                 variant="stacked"
                 fontSize={22}
-                color="#022a6e"
+                color="var(--arm-panel-bg-deep)"
               />
             </div>
 
             <div
               className="mb-5 p-3 bg-chrome-blue"
-              style={{ border: "3px solid #022a6e", boxShadow: "3px 3px 0 #022a6e" }}
+              style={{ border: "3px solid var(--arm-panel-bg-deep)", boxShadow: "3px 3px 0 var(--arm-shadow)" }}
             >
               <div className="flex items-center gap-2 mb-2">
                 <div
@@ -288,9 +288,9 @@ export default function NotFound() {
                 href="/"
                 className="px-5 py-2.5 cursor-pointer inline-flex items-center gap-2 font-grotesk font-bold bg-white text-chrome-blue"
                 style={{
-                  border: "3px solid #022a6e",
+                  border: "3px solid var(--arm-panel-bg-deep)",
                   fontSize: "12px",
-                  boxShadow: "3px 3px 0 #022a6e",
+                  boxShadow: "3px 3px 0 var(--arm-shadow)",
                   textDecoration: "none",
                   transition: "transform 0.2s ease, box-shadow 0.2s ease",
                 }}
@@ -304,9 +304,9 @@ export default function NotFound() {
                 className="px-5 py-2.5 cursor-pointer inline-flex items-center gap-2 font-grotesk font-bold bg-chrome-blue-mid"
                 style={{
                   color: "#e8f4ff",
-                  border: "3px solid #022a6e",
+                  border: "3px solid var(--arm-panel-bg-deep)",
                   fontSize: "12px",
-                  boxShadow: "3px 3px 0 #022a6e",
+                  boxShadow: "3px 3px 0 var(--arm-shadow)",
                   transition: "transform 0.2s ease, box-shadow 0.2s ease",
                 }}
                 onClick={() => window.history.back()}
@@ -334,7 +334,7 @@ export default function NotFound() {
               </div>
               <div
                 className="h-2.5 w-full overflow-hidden border-2 border-chrome-blue-dark"
-                style={{ backgroundColor: "#e8e4dc" }}
+                style={{ backgroundColor: "var(--arm-bg-card)" }}
               >
                 <motion.div
                   className="h-full bg-chrome-red"

--- a/app/playlists/PlaylistsClient.tsx
+++ b/app/playlists/PlaylistsClient.tsx
@@ -26,7 +26,7 @@ import { genres, genreColors, getPlaylistsByGenre, type Playlist } from "@/data/
 
 const PLAYLISTS_PER_PAGE = 6;
 
-function EqualizerBars({ color = "#4ade80" }: { color?: string }) {
+function EqualizerBars({ color = "var(--chrome-green)" }: { color?: string }) {
   return (
     <div className="flex items-end gap-[2px]" style={{ height: 14 }}>
       {[0, 0.2, 0.1, 0.3, 0.15].map((delay, i) => (

--- a/components/content/CommentsSection.tsx
+++ b/components/content/CommentsSection.tsx
@@ -87,7 +87,7 @@ export function CommentsSection() {
               <svg width="18" height="18" viewBox="0 0 20 20">
                 <polygon
                   points="10,1 13,7 19,7.5 14.5,12 16,18 10,15 4,18 5.5,12 1,7.5 7,7"
-                  fill="#4ade80"
+                  fill="var(--chrome-green)"
                   stroke="var(--arm-panel-bg-deep)"
                   strokeWidth="1.5"
                 />
@@ -122,7 +122,7 @@ export function CommentsSection() {
                 fontSize={12}
                 amplitude={2}
                 frequency={0.25}
-                color="#4ade80"
+                color="var(--chrome-green)"
               />
               <div
                 className="mt-2 p-2"

--- a/components/content/NowPlaying.tsx
+++ b/components/content/NowPlaying.tsx
@@ -51,7 +51,7 @@ function EqualizerBars({ playing, barCount = 5 }: { playing: boolean; barCount?:
           key={i}
           style={{
             width: 3,
-            backgroundColor: i % 2 === 0 ? "#4ade80" : "#80b0ff",
+            backgroundColor: i % 2 === 0 ? "var(--chrome-green)" : "var(--arm-panel-text-soft)",
             borderRadius: 1,
             height: playing ? undefined : 3,
             animation: playing
@@ -125,11 +125,11 @@ export function MusicConsentBar({
         className="flex flex-col sm:flex-row items-center gap-3 sm:gap-4 px-4 py-3 max-w-xl w-full"
         style={{
           pointerEvents: "auto",
-          border: "3px solid #022a6e",
+          border: "3px solid var(--arm-panel-bg-deep)",
           backgroundColor: "rgba(3,71,193,0.92)",
           backdropFilter: "blur(16px)",
           WebkitBackdropFilter: "blur(16px)",
-          boxShadow: "4px 4px 0 #022a6e, 0 -4px 24px rgba(3,71,193,0.3)",
+          boxShadow: "4px 4px 0 var(--arm-panel-bg-deep), 0 -4px 24px rgba(3,71,193,0.3)",
         }}
       >
         <div
@@ -143,7 +143,7 @@ export function MusicConsentBar({
           <div
             className="w-9 h-9 flex items-center justify-center flex-shrink-0 border-2 border-chrome-blue-soft bg-chrome-blue-mid"
           >
-            <Music size={16} color="#4ade80" />
+            <Music size={16} color="var(--chrome-green)" />
           </div>
           <div className="min-w-0">
             <div className="font-grotesk font-bold text-white" style={{ fontSize: "13px" }}>
@@ -161,16 +161,16 @@ export function MusicConsentBar({
             className="px-4 py-1.5 cursor-pointer font-grotesk font-bold text-chrome-blue bg-white border-2 border-chrome-blue-dark"
             style={{
               fontSize: "12px",
-              boxShadow: "2px 2px 0 #022a6e",
+              boxShadow: "2px 2px 0 var(--arm-panel-bg-deep)",
               transition: "transform 0.15s, box-shadow 0.15s",
             }}
             onMouseEnter={(e) => {
               e.currentTarget.style.transform = "translate(-1px, -1px)";
-              e.currentTarget.style.boxShadow = "3px 3px 0 #022a6e";
+              e.currentTarget.style.boxShadow = "3px 3px 0 var(--arm-panel-bg-deep)";
             }}
             onMouseLeave={(e) => {
               e.currentTarget.style.transform = "translate(0,0)";
-              e.currentTarget.style.boxShadow = "2px 2px 0 #022a6e";
+              e.currentTarget.style.boxShadow = "2px 2px 0 var(--arm-panel-bg-deep)";
             }}
           >
             Sim!
@@ -298,8 +298,8 @@ export function NowPlayingWidget() {
       <div
         className="flex items-center gap-3 px-4 py-2 cursor-pointer bg-chrome-blue"
         style={{
-          border: "3px solid #022a6e",
-          boxShadow: "4px 4px 0 #022a6e",
+          border: "3px solid var(--arm-panel-bg-deep)",
+          boxShadow: "4px 4px 0 var(--arm-panel-bg-deep)",
         }}
         onClick={() => setMinimized(false)}
       >
@@ -329,8 +329,8 @@ export function NowPlayingWidget() {
     <div
       className="flex flex-col"
       style={{
-        border: "3px solid #022a6e",
-        boxShadow: "4px 4px 0 #022a6e",
+        border: "3px solid var(--arm-panel-bg-deep)",
+        boxShadow: "4px 4px 0 var(--arm-panel-bg-deep)",
         overflow: "hidden",
       }}
     >
@@ -363,7 +363,7 @@ export function NowPlayingWidget() {
       <div
         className="flex items-center justify-between px-3 py-1 bg-chrome-blue-mid"
         style={{
-          borderBottom: "2px solid #022a6e",
+          borderBottom: "2px solid var(--arm-panel-bg-deep)",
           minHeight: "26px",
         }}
       >
@@ -464,8 +464,8 @@ export function NowPlayingWidget() {
                 onClick={prevTrack}
                 className="w-7 h-7 flex items-center justify-center cursor-pointer border-2 border-chrome-blue-accent bg-chrome-blue-mid text-chrome-blue-content"
                 style={{ transition: "background 0.15s" }}
-                onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#0560e0")}
-                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "#0458d4")}
+                onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "var(--arm-panel-border)")}
+                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "var(--arm-panel-bg)")}
               >
                 <SkipBack size={12} fill="currentColor" />
               </button>
@@ -474,16 +474,16 @@ export function NowPlayingWidget() {
                 onClick={togglePlay}
                 className="w-8 h-8 flex items-center justify-center cursor-pointer bg-white text-chrome-blue border-2 border-chrome-blue-dark"
                 style={{
-                  boxShadow: "2px 2px 0 #022a6e",
+                  boxShadow: "2px 2px 0 var(--arm-panel-bg-deep)",
                   transition: "transform 0.15s, box-shadow 0.15s",
                 }}
                 onMouseEnter={(e) => {
                   e.currentTarget.style.transform = "translate(-1px,-1px)";
-                  e.currentTarget.style.boxShadow = "3px 3px 0 #022a6e";
+                  e.currentTarget.style.boxShadow = "3px 3px 0 var(--arm-panel-bg-deep)";
                 }}
                 onMouseLeave={(e) => {
                   e.currentTarget.style.transform = "translate(0,0)";
-                  e.currentTarget.style.boxShadow = "2px 2px 0 #022a6e";
+                  e.currentTarget.style.boxShadow = "2px 2px 0 var(--arm-panel-bg-deep)";
                 }}
               >
                 {playing ? <Pause size={14} /> : <Play size={14} />}
@@ -493,8 +493,8 @@ export function NowPlayingWidget() {
                 onClick={nextTrack}
                 className="w-7 h-7 flex items-center justify-center cursor-pointer border-2 border-chrome-blue-accent bg-chrome-blue-mid text-chrome-blue-content"
                 style={{ transition: "background 0.15s" }}
-                onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "#0560e0")}
-                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "#0458d4")}
+                onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = "var(--arm-panel-border)")}
+                onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = "var(--arm-panel-bg)")}
               >
                 <SkipForward size={12} fill="currentColor" />
               </button>
@@ -520,7 +520,7 @@ export function NowPlayingWidget() {
                   setMuted(false);
                 }}
                 className="w-14 h-1 cursor-pointer"
-                style={{ accentColor: "#4ade80" }}
+                style={{ accentColor: "var(--chrome-green)" }}
               />
             </div>
 
@@ -530,14 +530,14 @@ export function NowPlayingWidget() {
       </div>
 
       {/* Track list — foobar2000 style */}
-      <div className="bg-chrome-blue-dark" style={{ borderTop: "2px solid #022a6e" }}>
+      <div className="bg-chrome-blue-dark" style={{ borderTop: "2px solid var(--arm-panel-bg-deep)" }}>
         {TRACKS.map((t, i) => (
           <div
             key={i}
             className="flex items-center gap-2 px-3 py-1.5 cursor-pointer"
             style={{
-              backgroundColor: i === currentTrack ? "#0458d4" : "transparent",
-              borderBottom: i < TRACKS.length - 1 ? "1px solid #0a3a7a" : "none",
+              backgroundColor: i === currentTrack ? "var(--arm-panel-bg)" : "transparent",
+              borderBottom: i < TRACKS.length - 1 ? "1px solid var(--arm-panel-bg-deep)" : "none",
               transition: "background 0.15s",
             }}
             onClick={() => {
@@ -546,7 +546,7 @@ export function NowPlayingWidget() {
               setTimeout(() => audioRef.current?.play().catch(() => {}), 100);
             }}
             onMouseEnter={(e) => {
-              if (i !== currentTrack) e.currentTarget.style.backgroundColor = "#0a3a7a";
+              if (i !== currentTrack) e.currentTarget.style.backgroundColor = "var(--arm-panel-bg-deep)";
             }}
             onMouseLeave={(e) => {
               if (i !== currentTrack) e.currentTarget.style.backgroundColor = "transparent";
@@ -556,7 +556,7 @@ export function NowPlayingWidget() {
               className="font-mono"
               style={{
                 fontSize: "9px",
-                color: i === currentTrack ? "#4ade80" : "#a0c4ff",
+                color: i === currentTrack ? "var(--chrome-green)" : "var(--arm-panel-text-body)",
                 width: 16,
                 textAlign: "center",
                 flexShrink: 0,
@@ -569,7 +569,7 @@ export function NowPlayingWidget() {
               style={{
                 fontSize: "11px",
                 fontWeight: i === currentTrack ? 700 : 400,
-                color: i === currentTrack ? "#fff" : "#c8e0ff",
+                color: i === currentTrack ? "var(--arm-panel-text)" : "var(--arm-panel-text-content)",
               }}
             >
               {t.artist} — {t.title}

--- a/components/content/SideContent.tsx
+++ b/components/content/SideContent.tsx
@@ -50,8 +50,8 @@ export function SideContent() {
                 className="w-8 h-8 flex items-center justify-center flex-shrink-0"
                 style={{
                   border: "2px solid var(--arm-border)",
-                  backgroundColor: i % 2 === 0 ? "var(--arm-blue)" : "#4ade80",
-                  color: i % 2 === 0 ? "#fff" : "var(--arm-text)",
+                  backgroundColor: i % 2 === 0 ? "var(--arm-blue)" : "var(--chrome-green)",
+                  color: i % 2 === 0 ? "var(--arm-panel-text)" : "var(--arm-text)",
                 }}
               >
                 <item.icon size={14} strokeWidth={2.5} />

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -64,10 +64,10 @@ export function Sidebar({
       ].join(" ")}
       style={{
         width: mobileOpen ? "min(280px, 80vw)" : width,
-        backgroundColor: "#0347c1",
-        borderRight: "3px solid #022a6e",
+        backgroundColor: "var(--arm-blue)",
+        borderRight: "3px solid var(--arm-panel-bg-deep)",
         fontFamily: "'Space Grotesk', sans-serif",
-        boxShadow: "4px 0 0 #022a6e",
+        boxShadow: "4px 0 0 var(--arm-panel-bg-deep)",
         transition: "width 0.3s cubic-bezier(0.4, 0, 0.2, 1), transform 0.3s ease-in-out",
       }}
       onMouseEnter={() => collapsed && setHovered(true)}
@@ -103,7 +103,7 @@ export function Sidebar({
       {/* Title bar */}
       <div
         className="flex items-center justify-between px-3 py-1.5 flex-shrink-0 bg-chrome-blue-mid"
-        style={{ borderBottom: "2px solid #022a6e", minHeight: "28px" }}
+        style={{ borderBottom: "2px solid var(--arm-panel-bg-deep)", minHeight: "28px" }}
       >
         {isExpanded ? (
           <span
@@ -123,11 +123,11 @@ export function Sidebar({
         <div className="flex items-center gap-1 flex-shrink-0">
           <div
             className="w-3 h-3 bg-chrome-blue"
-            style={{ border: "1.5px solid #0560e0" }}
+            style={{ border: "1.5px solid var(--arm-panel-border)" }}
           />
           <div
             className="w-3 h-3 bg-chrome-red"
-            style={{ border: "1.5px solid #0560e0" }}
+            style={{ border: "1.5px solid var(--arm-panel-border)" }}
           />
         </div>
       </div>
@@ -144,7 +144,7 @@ export function Sidebar({
           >
             <div
               className="w-10 h-10 flex items-center justify-center flex-shrink-0 overflow-hidden bg-chrome-blue-mid"
-              style={{ border: "3px solid #80b0ff" }}
+              style={{ border: "3px solid var(--arm-panel-text-soft)" }}
             >
               {/* Replace /avatar-pixel-art.png with the extracted Figma asset */}
               <Image
@@ -183,9 +183,9 @@ export function Sidebar({
                   className="flex items-center gap-3 transition-all overflow-hidden"
                   title={!isExpanded ? item.label : undefined}
                   style={{
-                    backgroundColor: isActive ? "#fff" : "transparent",
-                    color: isActive ? "#0347c1" : "#c8e0ff",
-                    border: isActive ? "2px solid #fff" : "2px solid transparent",
+                    backgroundColor: isActive ? "var(--arm-panel-text)" : "transparent",
+                    color: isActive ? "var(--arm-blue)" : "var(--arm-panel-text-content)",
+                    border: isActive ? "2px solid var(--arm-panel-text)" : "2px solid transparent",
                     fontWeight: isActive ? 700 : 500,
                     fontSize: "14px",
                     padding: isExpanded ? "10px 12px" : "10px",
@@ -206,8 +206,8 @@ export function Sidebar({
             title={!isExpanded ? "Notificações" : undefined}
             style={{
               backgroundColor: "rgba(74,222,128,0)",
-              border: "2px solid #4ade80",
-              color: "#4ade80",
+              border: "2px solid var(--chrome-green)",
+              color: "var(--chrome-green)",
               fontWeight: 700,
               fontSize: "14px",
               padding: isExpanded ? "10px 12px" : "10px",
@@ -218,8 +218,8 @@ export function Sidebar({
               width: "100%",
             }}
             whileHover={{
-              backgroundColor: "#4ade80",
-              color: "#022a6e",
+              backgroundColor: "var(--chrome-green)",
+              color: "var(--arm-panel-bg-deep)",
               boxShadow: "0 0 16px rgba(74,222,128,0.25)",
             }}
             whileTap={{ scale: 0.97 }}
@@ -266,7 +266,7 @@ export function Sidebar({
                   rx="28"
                   ry="28"
                   fill="none"
-                  stroke="#80b0ff"
+                  stroke="var(--arm-panel-text-soft)"
                   strokeWidth="1.5"
                 />
                 <ellipse
@@ -275,7 +275,7 @@ export function Sidebar({
                   rx="18"
                   ry="28"
                   fill="none"
-                  stroke="#80b0ff"
+                  stroke="var(--arm-panel-text-soft)"
                   strokeWidth="1"
                 />
                 <ellipse
@@ -284,7 +284,7 @@ export function Sidebar({
                   rx="8"
                   ry="28"
                   fill="none"
-                  stroke="#80b0ff"
+                  stroke="var(--arm-panel-text-soft)"
                   strokeWidth="1"
                 />
                 <line x1="2" y1="20" x2="58" y2="20" stroke="#80b0ff" strokeWidth="1" />

--- a/components/layout/newsletter/NewsletterModal.tsx
+++ b/components/layout/newsletter/NewsletterModal.tsx
@@ -90,14 +90,14 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
               className="relative w-full max-w-[460px]"
               onClick={(e) => e.stopPropagation()}
               style={{
-                border: "3px solid #022a6e",
-                boxShadow: "8px 8px 0 #022a6e, 0 0 60px rgba(3,71,193,0.3)",
+                border: "3px solid var(--arm-panel-bg-deep)",
+                boxShadow: "8px 8px 0 var(--arm-panel-bg-deep), 0 0 60px rgba(3,71,193,0.3)",
               }}
             >
               {/* Title bar */}
               <div
                 className="flex items-center justify-between px-3 py-2 bg-chrome-blue-mid"
-                style={{ borderBottom: "2px solid #022a6e" }}
+                style={{ borderBottom: "2px solid var(--arm-panel-bg-deep)" }}
               >
                 <div className="flex items-center gap-2">
                   <motion.div
@@ -108,7 +108,7 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                       repeatDelay: 3,
                     }}
                   >
-                    <Bell size={12} style={{ color: "#4ade80" }} />
+                    <Bell size={12} style={{ color: "var(--chrome-green)" }} />
                   </motion.div>
                   <span
                     className="font-mono font-bold text-chrome-blue-content"
@@ -120,17 +120,17 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                 <div className="flex items-center gap-1.5">
                   <div
                     className="w-3 h-3 bg-chrome-blue"
-                    style={{ border: "1.5px solid #022a6e" }}
+                    style={{ border: "1.5px solid var(--arm-panel-bg-deep)" }}
                   />
                   <motion.button
                     className="w-3 h-3 flex items-center justify-center cursor-pointer bg-chrome-red"
-                    style={{ border: "1.5px solid #022a6e", padding: 0 }}
+                    style={{ border: "1.5px solid var(--arm-panel-bg-deep)", padding: 0 }}
                     whileHover={{ scale: 1.2 }}
                     whileTap={{ scale: 0.9 }}
                     onClick={onClose}
                     aria-label="Fechar"
                   >
-                    <X size={7} style={{ color: "#022a6e" }} />
+                    <X size={7} style={{ color: "var(--arm-panel-bg-deep)" }} />
                   </motion.button>
                 </div>
               </div>
@@ -182,8 +182,8 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           <motion.div
                             className="w-11 h-11 flex items-center justify-center flex-shrink-0"
                             style={{
-                              border: "2px solid #4ade80",
-                              backgroundColor: "#4ade8012",
+                              border: "2px solid var(--chrome-green)",
+                              backgroundColor: "var(--chrome-green-tint)",
                               boxShadow: "0 0 16px rgba(74,222,128,0.15)",
                             }}
                             animate={{ rotate: [0, 6, -6, 0] }}
@@ -193,7 +193,7 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                               repeatDelay: 4,
                             }}
                           >
-                            <Bell size={20} style={{ color: "#4ade80" }} />
+                            <Bell size={20} style={{ color: "var(--chrome-green)" }} />
                           </motion.div>
                           <div>
                             <span
@@ -241,11 +241,11 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                                 transition: "border-color 0.2s, box-shadow 0.2s",
                               }}
                               onFocus={(e) => {
-                                e.currentTarget.style.borderColor = "#4ade80";
+                                e.currentTarget.style.borderColor = "var(--chrome-green)";
                                 e.currentTarget.style.boxShadow = "0 0 12px rgba(74,222,128,0.15)";
                               }}
                               onBlur={(e) => {
-                                e.currentTarget.style.borderColor = "#0560e0";
+                                e.currentTarget.style.borderColor = "var(--arm-panel-border)";
                                 e.currentTarget.style.boxShadow = "none";
                               }}
                             />
@@ -260,7 +260,7 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                                 exit={{ opacity: 0, y: -4 }}
                                 transition={{ duration: 0.2 }}
                                 className="mb-3 -mt-1 font-mono"
-                                style={{ fontSize: "9px", color: "#ff6b6b" }}
+                                style={{ fontSize: "9px", color: "var(--chrome-red-soft)" }}
                               >
                                 {error}
                               </motion.p>
@@ -272,20 +272,20 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                             type="submit"
                             className="w-full flex items-center justify-center gap-2 px-5 py-3 font-mono font-bold bg-chrome-green text-chrome-blue-dark cursor-pointer"
                             style={{
-                              border: "3px solid #022a6e",
-                              boxShadow: "4px 4px 0 #022a6e",
+                              border: "3px solid var(--arm-panel-bg-deep)",
+                              boxShadow: "4px 4px 0 var(--arm-panel-bg-deep)",
                               fontSize: "11px",
                             }}
                             whileHover={{
                               x: -2,
                               y: -2,
-                              boxShadow: "6px 6px 0 #022a6e",
-                              backgroundColor: "#6ee7a0",
+                              boxShadow: "6px 6px 0 var(--arm-panel-bg-deep)",
+                              backgroundColor: "var(--chrome-green-soft)",
                             }}
                             whileTap={{
                               x: 1,
                               y: 1,
-                              boxShadow: "2px 2px 0 #022a6e",
+                              boxShadow: "2px 2px 0 var(--arm-panel-bg-deep)",
                             }}
                             onMouseEnter={() => setBtnHover(true)}
                             onMouseLeave={() => setBtnHover(false)}
@@ -350,12 +350,12 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           }}
                           className="mb-4 w-16 h-16 flex items-center justify-center"
                           style={{
-                            border: "3px solid #4ade80",
-                            backgroundColor: "#4ade8015",
+                            border: "3px solid var(--chrome-green)",
+                            backgroundColor: "var(--chrome-green-tint)",
                             boxShadow: "0 0 30px rgba(74,222,128,0.2)",
                           }}
                         >
-                          <CheckCircle size={36} style={{ color: "#4ade80" }} />
+                          <CheckCircle size={36} style={{ color: "var(--chrome-green)" }} />
                         </motion.div>
 
                         <motion.span
@@ -414,7 +414,7 @@ export function NewsletterModal({ open, onClose }: NewsletterModalProps) {
                           className="mt-5 px-5 py-2 cursor-pointer font-mono font-bold bg-chrome-blue-mid text-chrome-blue-content border-2 border-chrome-blue-accent"
                           style={{ fontSize: "10px" }}
                           whileHover={{
-                            backgroundColor: "#0560e0",
+                            backgroundColor: "var(--arm-panel-border)",
                             color: "#fff",
                           }}
                           onClick={onClose}

--- a/components/layout/newsletter/NewsletterWidget.tsx
+++ b/components/layout/newsletter/NewsletterWidget.tsx
@@ -64,7 +64,7 @@ export function NewsletterWidget() {
                 <div className="flex items-start gap-3 mb-3">
                   <motion.div
                     className="flex-shrink-0 w-9 h-9 flex items-center justify-center mt-0.5 border-2 border-chrome-green text-chrome-green"
-                    style={{ backgroundColor: "#4ade8015" }}
+                    style={{ backgroundColor: "var(--chrome-green-tint)" }}
                     animate={{ rotate: [0, 8, -8, 0] }}
                     transition={{
                       duration: 2.5,
@@ -97,7 +97,7 @@ export function NewsletterWidget() {
                     <Mail
                       size={13}
                       className="absolute left-2.5 top-1/2 -translate-y-1/2"
-                      style={{ color: "#a0c4ff" }}
+                      style={{ color: "var(--arm-panel-text-body)" }}
                     />
                     <input
                       type="email"
@@ -112,11 +112,11 @@ export function NewsletterWidget() {
                         transition: "border-color 0.2s, box-shadow 0.2s",
                       }}
                       onFocus={(e) => {
-                        e.currentTarget.style.borderColor = "#4ade80";
+                        e.currentTarget.style.borderColor = "var(--chrome-green)";
                         e.currentTarget.style.boxShadow = "0 0 10px rgba(74,222,128,0.15)";
                       }}
                       onBlur={(e) => {
-                        e.currentTarget.style.borderColor = "#0560e0";
+                        e.currentTarget.style.borderColor = "var(--arm-panel-border)";
                         e.currentTarget.style.boxShadow = "none";
                       }}
                     />
@@ -126,21 +126,21 @@ export function NewsletterWidget() {
                     type="submit"
                     className="flex items-center justify-center gap-2 px-5 py-2.5 font-mono font-bold bg-chrome-green text-chrome-blue-dark cursor-pointer"
                     style={{
-                      border: "3px solid #022a6e",
-                      boxShadow: "4px 4px 0 #022a6e",
+                      border: "3px solid var(--arm-panel-bg-deep)",
+                      boxShadow: "4px 4px 0 var(--arm-panel-bg-deep)",
                       fontSize: "10px",
                       flexShrink: 0,
                     }}
                     whileHover={{
                       x: -2,
                       y: -2,
-                      boxShadow: "6px 6px 0 #022a6e",
-                      backgroundColor: "#6ee7a0",
+                      boxShadow: "6px 6px 0 var(--arm-panel-bg-deep)",
+                      backgroundColor: "var(--chrome-green-soft)",
                     }}
                     whileTap={{
                       x: 1,
                       y: 1,
-                      boxShadow: "2px 2px 0 #022a6e",
+                      boxShadow: "2px 2px 0 var(--arm-panel-bg-deep)",
                     }}
                     onMouseEnter={() => setBtnHover(true)}
                     onMouseLeave={() => setBtnHover(false)}
@@ -164,7 +164,7 @@ export function NewsletterWidget() {
                       exit={{ opacity: 0, y: -4 }}
                       transition={{ duration: 0.2 }}
                       className="mt-1.5 font-mono"
-                      style={{ fontSize: "9px", color: "#ff6b6b" }}
+                      style={{ fontSize: "9px", color: "var(--chrome-red-soft)" }}
                     >
                       {error}
                     </motion.p>

--- a/components/ui/Pagination.tsx
+++ b/components/ui/Pagination.tsx
@@ -15,21 +15,21 @@ const paginationButtonStyle: React.CSSProperties = {
   fontFamily: "'Space Mono', monospace",
   fontSize: "11px",
   fontWeight: 700,
-  border: "2px solid #0560e0",
-  backgroundColor: "#0458d4",
-  color: "#c8e0ff",
+  border: "2px solid var(--arm-panel-border)",
+  backgroundColor: "var(--arm-panel-bg)",
+  color: "var(--arm-panel-text-content)",
   cursor: "pointer",
 };
 
 const activePageStyle: React.CSSProperties = {
   ...paginationButtonStyle,
-  backgroundColor: "#fff",
-  color: "#0347c1",
-  border: "2px solid #022a6e",
-  boxShadow: "2px 2px 0 #022a6e",
+  backgroundColor: "var(--arm-panel-text)",
+  color: "var(--arm-blue)",
+  border: "2px solid var(--arm-panel-bg-deep)",
+  boxShadow: "2px 2px 0 var(--arm-panel-bg-deep)",
 };
 
-const hoverAnim = { x: -1, y: -1, boxShadow: "3px 3px 0 #022a6e" };
+const hoverAnim = { x: -1, y: -1, boxShadow: "3px 3px 0 var(--arm-panel-bg-deep)" };
 const tapAnim = { x: 0, y: 0 };
 
 export function Pagination({
@@ -46,18 +46,18 @@ export function Pagination({
   return (
     <div className="mt-5 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
       <div className="flex items-center gap-2">
-        <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "9px", color: "#a0c4ff" }}>
+        <span style={{ fontFamily: "'Space Mono', monospace", fontSize: "9px", color: "var(--arm-panel-text-body)" }}>
           SHOWING {startIdx + 1}-{Math.min(startIdx + itemsPerPage, totalItems)} OF {totalItems}
         </span>
         <div
           className="h-2 overflow-hidden"
-          style={{ width: "80px", border: "1.5px solid #0560e0", backgroundColor: "#022a6e" }}
+          style={{ width: "80px", border: "1.5px solid var(--arm-panel-border)", backgroundColor: "var(--arm-panel-bg-deep)" }}
         >
           <div
             className="h-full"
             style={{
               width: `${(currentPage / totalPages) * 100}%`,
-              backgroundColor: "#4ade80",
+              backgroundColor: "var(--chrome-green)",
               transition: "width 0.3s ease",
             }}
           />

--- a/components/ui/RetroWindow.tsx
+++ b/components/ui/RetroWindow.tsx
@@ -24,14 +24,14 @@ export function RetroWindow({
   const isDark = variant === "dark";
   const isGlass = variant === "glass";
 
-  const borderColor = borderColorOverride ?? (isDark ? "#022a6e" : "var(--arm-border)");
+  const borderColor = borderColorOverride ?? (isDark ? "var(--arm-panel-bg-deep)" : "var(--arm-border)");
   const titleBg = titleBgOverride ?? (isGlass
     ? "var(--arm-bg-glass-title)"
     : isDark
-      ? "#0458d4"
+      ? "var(--arm-panel-bg)"
       : "var(--arm-bg-card-title)");
-  const titleText = isGlass ? "#fff" : isDark ? "#fff" : "var(--arm-text)";
-  const bodyBg = isGlass ? "var(--arm-glass-body)" : isDark ? "#0347c1" : "var(--arm-bg-card)";
+  const titleText = isGlass ? "var(--arm-panel-text)" : isDark ? "var(--arm-panel-text)" : "var(--arm-text)";
+  const bodyBg = isGlass ? "var(--arm-glass-body)" : isDark ? "var(--arm-panel-bg-darker)" : "var(--arm-bg-card)";
 
   const glassStyles: React.CSSProperties = isGlass
     ? {
@@ -46,7 +46,7 @@ export function RetroWindow({
       className={`flex flex-col ${className}`}
       style={{
         border: `3px solid ${borderColor}`,
-        boxShadow: `4px 4px 0px ${isDark ? "#022a6e" : "var(--arm-shadow)"}`,
+        boxShadow: `4px 4px 0px ${isDark ? "var(--arm-panel-bg-deep)" : "var(--arm-shadow)"}`,
         ...glassStyles,
         ...style,
       }}
@@ -77,7 +77,7 @@ export function RetroWindow({
               className="w-4 h-4 flex items-center justify-center"
               style={{
                 border: `2px solid ${borderColor}`,
-                backgroundColor: isDark ? "#0560e0" : "var(--arm-bg-card-title)",
+                backgroundColor: isDark ? "var(--arm-panel-border)" : "var(--arm-bg-card-title)",
                 fontSize: "10px",
                 fontWeight: 700,
                 lineHeight: 1,

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -15,7 +15,10 @@
   --chrome-blue-content: #c0d8ff;
   --chrome-blue-text-on-dark: #c8e0ff;
   --chrome-green: #4ade80;
+  --chrome-green-soft: #6ee7a0;
+  --chrome-green-tint: rgba(74, 222, 128, 0.08);
   --chrome-red: #e05050;
+  --chrome-red-soft: #ff6b6b;
   --chrome-purple: #c084fc;
   --chrome-amber: #f59e0b;
 


### PR DESCRIPTION
## Summary

- Replaces all matched hardcoded hex values across 10 components with `var(--*)` CSS tokens
- Adds 3 new tokens to `styles/theme.css`: `--chrome-green-soft`, `--chrome-green-tint`, `--chrome-red-soft`
- Prerequisite for issue #39 (site blue remap) — after this, changing the palette only requires touching `theme.css`

## Files changed

| File | Changes |
|---|---|
| `styles/theme.css` | +3 new tokens |
| `components/ui/RetroWindow.tsx` | All internal hex → CSS vars |
| `components/layout/Sidebar.tsx` | Blues, greens, whites tokenized |
| `components/layout/newsletter/NewsletterModal.tsx` | All blues, greens, error red tokenized |
| `components/layout/newsletter/NewsletterWidget.tsx` | Greens, border focus states tokenized |
| `components/content/NowPlaying.tsx` | Player chrome + track list tokenized |
| `components/content/CommentsSection.tsx` | Star fill, chart colors tokenized |
| `components/content/SideContent.tsx` | Icon background colors tokenized |
| `components/ui/Pagination.tsx` | All button styles tokenized |
| `app/not-found.tsx` | Borders, shadows, progress bar tokenized |
| `app/playlists/PlaylistsClient.tsx` | Equalizer default color tokenized |

## Skipped (intentional)

- `AeroElements.tsx` — SVG pixel art, values are intentional design assets
- Google OAuth colors (`#4285F4`, `#34A853`, `#EA4335`, `#FBBC05`) — external brand
- Spotify green (`#1DB954`) — external brand
- macOS-style window buttons in `Header.tsx` — intentional system UI aesthetic
- Glitch/corrupted animation values in `PostsClient.tsx` — intentional glitch art

## Test plan

- [ ] `npx tsc --noEmit` passes (zero errors)
- [ ] Homepage renders without color regressions
- [ ] Newsletter modal opens and displays correctly
- [ ] NowPlaying player chrome looks correct
- [ ] Pagination component renders correctly
- [ ] 404 page renders correctly