### PR TITLE
feat: avatar file picker + WP Admin user panel with audit log (#45, #47)

### DIFF
--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+
+const wpBase = process.env.WORDPRESS_API_URL
+  ?.replace(/\/graphql\/?$/, "")
+  .replace(/\/$/, "");
+
+function getAuthHeader() {
+  const user = process.env.WP_APP_USER;
+  const pass = process.env.WP_APP_PASSWORD;
+  if (!user || !pass) throw new Error("WP credentials not set");
+  return `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const formData = await req.formData().catch(() => null);
+  const file = formData?.get("file");
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Nenhum arquivo enviado" }, { status: 400 });
+  }
+
+  if (!file.type.startsWith("image/")) {
+    return NextResponse.json({ error: "Apenas imagens são permitidas" }, { status: 400 });
+  }
+
+  if (file.size > 2 * 1024 * 1024) {
+    return NextResponse.json({ error: "Imagem deve ter menos de 2MB" }, { status: 400 });
+  }
+
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+
+    const res = await fetch(`${wpBase}/wp-json/wp/v2/media`, {
+      method: "POST",
+      headers: {
+        Authorization: getAuthHeader(),
+        "Content-Type": file.type,
+        "Content-Disposition": `attachment; filename="${safeName}"`,
+      },
+      body: buffer,
+    });
+
+    if (!res.ok) {
+      console.error("[POST /api/profile/avatar] WP error:", res.status, await res.text());
+      return NextResponse.json({ error: "Falha ao fazer upload" }, { status: 500 });
+    }
+
+    const media = await res.json();
+    return NextResponse.json({ url: media.source_url as string });
+  } catch (err) {
+    console.error("[POST /api/profile/avatar]", err);
+    return NextResponse.json({ error: "Erro interno" }, { status: 500 });
+  }
+}

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createHash } from "crypto";
 import { auth } from "@/auth";
 import { getUserProfile } from "@/lib/graphql/queries/profile";
+import { logProfileEvent } from "@/lib/wp";
 
 // Derive WP REST base from WORDPRESS_API_URL (strips /graphql suffix)
 const wpRestBase = process.env.WORDPRESS_API_URL
@@ -57,7 +58,6 @@ export async function PUT(req: Request) {
   const existing = await getUserProfile(hash).catch(() => null);
 
   if (existing) {
-    // Update existing profile via WP REST API
     const res = await fetch(`${wpRestBase}/wp-json/wp/v2/user-profile/${existing.databaseId}`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: authHeader },
@@ -67,9 +67,7 @@ export async function PUT(req: Request) {
       console.error("[PUT /api/profile] WP update failed:", await res.text());
       return NextResponse.json({ error: "Falha ao atualizar perfil" }, { status: 500 });
     }
-    return NextResponse.json({ ok: true });
   } else {
-    // Create new profile via WP REST API
     const res = await fetch(`${wpRestBase}/wp-json/wp/v2/user-profile`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: authHeader },
@@ -79,6 +77,21 @@ export async function PUT(req: Request) {
       console.error("[PUT /api/profile] WP create failed:", await res.text());
       return NextResponse.json({ error: "Falha ao criar perfil" }, { status: 500 });
     }
-    return NextResponse.json({ ok: true });
   }
+
+  // Log events in parallel — non-blocking, failures don't break the save
+  const events: Promise<void>[] = [];
+  if (displayName && displayName !== existing?.displayName) {
+    events.push(logProfileEvent({
+      hash,
+      event: "nick_change",
+      extra: { from: existing?.displayName ?? "", to: displayName },
+    }));
+  }
+  if (avatarUrl) {
+    events.push(logProfileEvent({ hash, event: "avatar_change" }));
+  }
+  await Promise.allSettled(events);
+
+  return NextResponse.json({ ok: true });
 }

--- a/app/minha-conta/ProfileForm.tsx
+++ b/app/minha-conta/ProfileForm.tsx
@@ -1,17 +1,22 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
-import Image from "next/image";
 import { RetroWindow } from "@/components/ui/RetroWindow";
+
+type UploadState = "idle" | "uploading" | "done" | "error";
 
 export function ProfileForm() {
   const { data: session, update } = useSession();
   const [displayName, setDisplayName] = useState("");
   const [avatarUrl, setAvatarUrl] = useState("");
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [uploadState, setUploadState] = useState<UploadState>("idle");
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState<{ ok: boolean; msg: string } | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     fetch("/api/profile")
@@ -20,14 +25,55 @@ export function ProfileForm() {
         if (profile) {
           setDisplayName(profile.displayName ?? "");
           setAvatarUrl(profile.avatarUrl ?? "");
+          setPreviewUrl(profile.avatarUrl ?? null);
         }
       })
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Show local preview immediately — user sees instant feedback
+    const blob = URL.createObjectURL(file);
+    setPreviewUrl(blob);
+    setUploadState("uploading");
+    setUploadError(null);
+    setFeedback(null);
+
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/profile/avatar", { method: "POST", body: fd });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Falha no upload");
+
+      URL.revokeObjectURL(blob);
+      setAvatarUrl(data.url);
+      setPreviewUrl(data.url);
+      setUploadState("done");
+    } catch (err) {
+      URL.revokeObjectURL(blob);
+      setPreviewUrl(avatarUrl || null); // revert to last saved avatar
+      setUploadState("error");
+      setUploadError(err instanceof Error ? err.message : "Falha no upload");
+    } finally {
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  }
+
+  function handleUseGooglePhoto() {
+    const url = session?.user?.image ?? null;
+    setAvatarUrl(url ?? "");
+    setPreviewUrl(url);
+    setUploadState("idle");
+    setUploadError(null);
+  }
+
   async function handleSave() {
-    if (saving) return;
+    if (saving || uploadState === "uploading") return;
     setSaving(true);
     setFeedback(null);
     try {
@@ -38,9 +84,9 @@ export function ProfileForm() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Erro desconhecido");
-      // Trigger JWT refresh so session.user.displayName updates immediately
       await update();
       setFeedback({ ok: true, msg: "PERFIL SALVO COM SUCESSO." });
+      setUploadState("idle");
     } catch (err) {
       setFeedback({ ok: false, msg: err instanceof Error ? err.message : "Erro ao salvar." });
     } finally {
@@ -48,8 +94,9 @@ export function ProfileForm() {
     }
   }
 
-  const previewAvatar = avatarUrl || session?.user?.image || null;
-  const previewName = displayName || session?.user?.name || "?";
+  const displayAvatar = previewUrl ?? session?.user?.image ?? null;
+  const displayName_ = displayName || session?.user?.name || "?";
+  const canSave = !saving && uploadState !== "uploading" && (displayName.trim() !== "" || avatarUrl !== "");
 
   if (loading) {
     return (
@@ -83,23 +130,21 @@ export function ProfileForm() {
               justifyContent: "center",
             }}
           >
-            {previewAvatar ? (
-              <Image
-                src={previewAvatar}
+            {displayAvatar ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={displayAvatar}
                 alt="avatar preview"
-                fill
-                sizes="80px"
-                className="object-cover"
-                unoptimized={!previewAvatar.startsWith("https://lh3.googleusercontent.com") && !previewAvatar.startsWith("https://secure.gravatar.com")}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
               />
             ) : (
               <span className="font-grotesk font-bold" style={{ fontSize: 28, color: "var(--arm-text)" }}>
-                {previewName[0]?.toUpperCase()}
+                {displayName_[0]?.toUpperCase()}
               </span>
             )}
           </div>
           <p className="font-mono font-bold" style={{ fontSize: "13px", color: "var(--arm-text)" }}>
-            {previewName.toUpperCase()}
+            {displayName_.toUpperCase()}
           </p>
           <p className="font-mono text-center" style={{ fontSize: "9px", color: "var(--arm-text-secondary)", lineHeight: 1.6 }}>
             Esses dados aparecem nos seus comentários.
@@ -109,7 +154,7 @@ export function ProfileForm() {
 
         <div style={{ height: "1px", backgroundColor: "var(--arm-border)", opacity: 0.2 }} />
 
-        {/* Display name field */}
+        {/* Display name */}
         <div className="flex flex-col gap-2">
           <label className="font-mono" style={{ fontSize: "9px", color: "var(--arm-text-secondary)", letterSpacing: "0.1em" }}>
             NOME DE EXIBIÇÃO
@@ -131,46 +176,88 @@ export function ProfileForm() {
           />
         </div>
 
-        {/* Avatar URL field */}
+        {/* Avatar upload */}
         <div className="flex flex-col gap-2">
           <label className="font-mono" style={{ fontSize: "9px", color: "var(--arm-text-secondary)", letterSpacing: "0.1em" }}>
-            URL DO AVATAR
+            FOTO DE PERFIL
           </label>
+
+          {/* Hidden file input — opened programmatically */}
           <input
-            type="url"
-            value={avatarUrl}
-            onChange={(e) => setAvatarUrl(e.target.value)}
-            placeholder="https://..."
-            className="w-full font-mono bg-transparent outline-none"
-            style={{
-              border: "2px solid var(--arm-border)",
-              padding: "8px 12px",
-              fontSize: "12px",
-              color: "var(--arm-text)",
-              backgroundColor: "var(--arm-bg-card)",
-            }}
+            ref={fileRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            className="hidden"
+            onChange={handleFileChange}
           />
-          {session?.user?.image && (
+
+          <div className="flex items-center gap-3 flex-wrap">
             <button
               type="button"
-              onClick={() => setAvatarUrl(session.user!.image!)}
-              className="self-start font-mono"
+              onClick={() => fileRef.current?.click()}
+              disabled={uploadState === "uploading"}
+              className="font-mono font-bold"
               style={{
-                fontSize: "9px",
-                color: "var(--arm-text-secondary)",
-                background: "none",
-                border: "none",
-                cursor: "pointer",
-                textDecoration: "underline",
-                padding: 0,
+                border: "2px solid var(--arm-border)",
+                backgroundColor: "var(--arm-bg-card)",
+                color: "var(--arm-text)",
+                fontSize: "10px",
+                padding: "6px 14px",
+                cursor: uploadState === "uploading" ? "wait" : "pointer",
+                letterSpacing: "0.06em",
+                transition: "transform 0.1s ease, box-shadow 0.1s ease",
+              }}
+              onMouseEnter={(e) => {
+                if (uploadState !== "uploading") {
+                  e.currentTarget.style.transform = "translate(-2px, -2px)";
+                  e.currentTarget.style.boxShadow = "3px 3px 0 var(--arm-border)";
+                }
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = "translate(0,0)";
+                e.currentTarget.style.boxShadow = "none";
               }}
             >
-              usar foto do Google
+              {uploadState === "uploading" ? "ENVIANDO..." : "ESCOLHER ARQUIVO"}
             </button>
+
+            {session?.user?.image && (
+              <button
+                type="button"
+                onClick={handleUseGooglePhoto}
+                className="font-mono"
+                style={{
+                  fontSize: "9px",
+                  color: "var(--arm-text-secondary)",
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  textDecoration: "underline",
+                  padding: 0,
+                }}
+              >
+                usar foto do Google
+              </button>
+            )}
+          </div>
+
+          {uploadState === "done" && (
+            <p className="font-mono" style={{ fontSize: "9px", color: "var(--chrome-green)", letterSpacing: "0.05em" }}>
+              ✓ Upload concluído — clique em SALVAR PERFIL para confirmar
+            </p>
           )}
+          {uploadState === "error" && uploadError && (
+            <p className="font-mono" style={{ fontSize: "9px", color: "var(--chrome-red)", letterSpacing: "0.05em" }}>
+              ✗ {uploadError}
+            </p>
+          )}
+
+          <p className="font-mono" style={{ fontSize: "9px", color: "var(--arm-text-secondary)", opacity: 0.6 }}>
+            JPG, PNG, WEBP ou GIF · máx. 2MB
+          </p>
         </div>
 
-        {/* Feedback */}
+        {/* Save feedback */}
         {feedback && (
           <p
             className="font-mono"
@@ -188,7 +275,7 @@ export function ProfileForm() {
         <button
           type="button"
           onClick={handleSave}
-          disabled={saving || (!displayName.trim() && !avatarUrl.trim())}
+          disabled={!canSave}
           className="w-full font-mono font-bold"
           style={{
             border: "2px solid var(--arm-border)",
@@ -197,12 +284,12 @@ export function ProfileForm() {
             fontSize: "11px",
             letterSpacing: "0.08em",
             padding: "10px 16px",
-            cursor: saving || (!displayName.trim() && !avatarUrl.trim()) ? "not-allowed" : "pointer",
-            opacity: saving || (!displayName.trim() && !avatarUrl.trim()) ? 0.5 : 1,
+            cursor: !canSave ? "not-allowed" : "pointer",
+            opacity: !canSave ? 0.5 : 1,
             transition: "transform 0.1s ease, box-shadow 0.1s ease",
           }}
           onMouseEnter={(e) => {
-            if (!saving) {
+            if (canSave) {
               e.currentTarget.style.transform = "translate(-2px, -2px)";
               e.currentTarget.style.boxShadow = "4px 4px 0 var(--arm-border)";
             }

--- a/auth.ts
+++ b/auth.ts
@@ -16,9 +16,14 @@ interface AppToken {
   [key: string]: unknown;
 }
 
-// On first login, auto-create a WP user-profile with the Google photo as default avatar.
+// On login, ensure the WP user-profile has an avatar.
+// Creates the profile if it doesn't exist; updates the avatar if the profile has none.
 // This makes comment avatars work immediately without the user visiting /minha-conta.
-async function ensureWPProfile(emailHash: string, googlePhotoUrl: string): Promise<void> {
+async function seedWPProfileAvatar(
+  emailHash: string,
+  googlePhotoUrl: string,
+  existingId?: number
+): Promise<void> {
   const wpBase = process.env.WORDPRESS_API_URL
     ?.replace(/\/graphql\/?$/, "")
     .replace(/\/$/, "");
@@ -28,16 +33,26 @@ async function ensureWPProfile(emailHash: string, googlePhotoUrl: string): Promi
 
   const authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
 
-  await fetch(`${wpBase}/wp-json/wp/v2/user-profile`, {
+  const url = existingId
+    ? `${wpBase}/wp-json/wp/v2/user-profile/${existingId}`
+    : `${wpBase}/wp-json/wp/v2/user-profile`;
+
+  const body = existingId
+    ? JSON.stringify({ meta: { avatar_url: googlePhotoUrl } })
+    : JSON.stringify({ title: emailHash, slug: emailHash, status: "publish", meta: { avatar_url: googlePhotoUrl } });
+
+  const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: authHeader },
-    body: JSON.stringify({
-      title: emailHash,
-      slug: emailHash,
-      status: "publish",
-      meta: { avatar_url: googlePhotoUrl },
-    }),
-  }).catch(() => null); // fire-and-forget — failure is non-critical
+    body,
+  }).catch((err) => {
+    console.error("[seedWPProfileAvatar] fetch failed:", err);
+    return null;
+  });
+
+  if (res && !res.ok) {
+    console.error("[seedWPProfileAvatar] WP REST error:", res.status, await res.text().catch(() => ""));
+  }
 }
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
@@ -54,9 +69,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
         const profile = await getUserProfile(hash).catch(() => null);
 
-        // First login and no profile yet → auto-seed with Google photo
-        if (!profile && (trigger === "signIn" || trigger === "signUp") && t.picture) {
-          await ensureWPProfile(hash, t.picture);
+        // On login: seed Google photo as avatar if profile has none
+        if ((trigger === "signIn" || trigger === "signUp") && t.picture) {
+          if (!profile) {
+            await seedWPProfileAvatar(hash, t.picture);
+          } else if (!profile.avatarUrl) {
+            await seedWPProfileAvatar(hash, t.picture, profile.databaseId);
+          }
         }
 
         t.displayName = profile?.displayName ?? null;

--- a/auth.ts
+++ b/auth.ts
@@ -2,6 +2,7 @@ import NextAuth, { type DefaultSession } from "next-auth";
 import Google from "next-auth/providers/google";
 import { createHash } from "crypto";
 import { getUserProfile } from "@/lib/graphql/queries/profile";
+import { logProfileEvent } from "@/lib/wp";
 
 declare module "next-auth" {
   interface Session {
@@ -14,45 +15,6 @@ interface AppToken {
   picture?: string | null;
   displayName?: string | null;
   [key: string]: unknown;
-}
-
-// On login, ensure the WP user-profile has an avatar.
-// Creates the profile if it doesn't exist; updates the avatar if the profile has none.
-// This makes comment avatars work immediately without the user visiting /minha-conta.
-async function seedWPProfileAvatar(
-  emailHash: string,
-  googlePhotoUrl: string,
-  existingId?: number
-): Promise<void> {
-  const wpBase = process.env.WORDPRESS_API_URL
-    ?.replace(/\/graphql\/?$/, "")
-    .replace(/\/$/, "");
-  const user = process.env.WP_APP_USER;
-  const pass = process.env.WP_APP_PASSWORD;
-  if (!wpBase || !user || !pass) return;
-
-  const authHeader = `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
-
-  const url = existingId
-    ? `${wpBase}/wp-json/wp/v2/user-profile/${existingId}`
-    : `${wpBase}/wp-json/wp/v2/user-profile`;
-
-  const body = existingId
-    ? JSON.stringify({ meta: { avatar_url: googlePhotoUrl } })
-    : JSON.stringify({ title: emailHash, slug: emailHash, status: "publish", meta: { avatar_url: googlePhotoUrl } });
-
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: authHeader },
-    body,
-  }).catch((err) => {
-    console.error("[seedWPProfileAvatar] fetch failed:", err);
-    return null;
-  });
-
-  if (res && !res.ok) {
-    console.error("[seedWPProfileAvatar] WP REST error:", res.status, await res.text().catch(() => ""));
-  }
 }
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
@@ -69,13 +31,16 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
         const profile = await getUserProfile(hash).catch(() => null);
 
-        // On login: seed Google photo as avatar if profile has none
+        // On login: record event + seed email/avatar via the PHP endpoint.
+        // The endpoint handles profile creation, private email storage, avatar seed
+        // (only if no avatar exists), and audit log — all in one authenticated call.
         if ((trigger === "signIn" || trigger === "signUp") && t.picture) {
-          if (!profile) {
-            await seedWPProfileAvatar(hash, t.picture);
-          } else if (!profile.avatarUrl) {
-            await seedWPProfileAvatar(hash, t.picture, profile.databaseId);
-          }
+          await logProfileEvent({
+            hash,
+            event: "login",
+            email: t.email ?? undefined,
+            avatar_url: t.picture,
+          });
         }
 
         t.displayName = profile?.displayName ?? null;

--- a/components/content/single-post/PostCommentsSection.tsx
+++ b/components/content/single-post/PostCommentsSection.tsx
@@ -86,7 +86,7 @@ export function PostCommentsSection({ postId, initialComments }: PostCommentsSec
                   <div className="w-6 h-6 overflow-hidden border border-chrome-blue-accent flex-shrink-0">
                     <AppImage
                       src={session.user.image}
-                      alt={session.user.name ?? ""}
+                      alt={session.user.displayName ?? session.user.name ?? ""}
                       width={24}
                       height={24}
                       sizes="24px"
@@ -95,7 +95,7 @@ export function PostCommentsSection({ postId, initialComments }: PostCommentsSec
                   </div>
                 )}
                 <span className="font-mono text-chrome-blue-soft" style={{ fontSize: "9px" }}>
-                  {session.user?.name?.toUpperCase()}
+                  {(session.user?.displayName ?? session.user?.name)?.toUpperCase()}
                 </span>
               </div>
 

--- a/docs/adr/ADR-011-session-jwt-displayname-cache.md
+++ b/docs/adr/ADR-011-session-jwt-displayname-cache.md
@@ -45,6 +45,18 @@ JWT salvo no cookie (assinado, httpOnly)
 
 O `displayName` fica dentro do token. Não precisa ser rebuscado enquanto o token for válido.
 
+#### Auto-seed de avatar no login
+
+Durante o login, o `jwt` callback também garante que o perfil WP tenha um avatar:
+
+```
+profile não existe → seedWPProfileAvatar(hash, googlePhoto)    → cria perfil com avatar
+profile existe, avatarUrl null → seedWPProfileAvatar(hash, googlePhoto, id) → atualiza perfil com avatar
+profile existe, avatarUrl preenchido → nada
+```
+
+O `seedWPProfileAvatar` faz POST para `WP REST /wp-json/wp/v2/user-profile` com `Application Password`. Erros são logados mas não bloqueiam o login — o avatar é não-crítico. O filtro PHP `pre_get_avatar_data` intercepta as chamadas de `get_avatar_data()` do WPGraphQL e retorna o avatar customizado automaticamente para todos os comentários do usuário.
+
 ### 2. Ao enviar um comentário
 
 ```
@@ -105,6 +117,8 @@ O JWT é o lugar certo: já existe, é assinado (não pode ser forjado), é envi
 
 | Arquivo | Mudança |
 |---|---|
-| `auth.ts` | Adicionados `jwt` e `session` callbacks; `Session` type estendido com `displayName` |
+| `auth.ts` | Adicionados `jwt` e `session` callbacks; `Session` type estendido com `displayName`; `seedWPProfileAvatar` para auto-seed de avatar no login |
 | `app/api/comments/route.ts` | Removida busca de perfil — usa `session.user.displayName` |
 | `app/minha-conta/ProfileForm.tsx` | Chama `update()` após salvar para invalidar o cache do JWT |
+| `components/content/single-post/PostCommentsSection.tsx` | Formulário exibe `displayName ?? name` — não o nome do Google diretamente |
+| `blog-cms/.../avatar-override.php` | Filtro `pre_get_avatar_data` retorna avatar customizado do CPT para todos os comentários |

--- a/lib/wp/index.ts
+++ b/lib/wp/index.ts
@@ -1,0 +1,2 @@
+export { logProfileEvent } from "./profile-events";
+export type { ProfileEventParams } from "./profile-events";

--- a/lib/wp/profile-events.ts
+++ b/lib/wp/profile-events.ts
@@ -1,0 +1,46 @@
+const wpBase = () =>
+  process.env.WORDPRESS_API_URL
+    ?.replace(/\/graphql\/?$/, "")
+    .replace(/\/$/, "") ?? "";
+
+function authHeader(): string {
+  const user = process.env.WP_APP_USER;
+  const pass = process.env.WP_APP_PASSWORD;
+  if (!user || !pass) return "";
+  return `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
+}
+
+export interface ProfileEventParams {
+  hash: string;
+  event: string;
+  email?: string;
+  avatar_url?: string;
+  extra?: Record<string, string>;
+}
+
+// Records a user lifecycle event (login, nick_change, avatar_change) in the WP
+// user-profile CPT. Also handles first-time profile creation, email storage
+// (private meta, admin-only), and avatar seeding — all in a single PHP endpoint
+// so private data never touches the public WP REST schema.
+export async function logProfileEvent(params: ProfileEventParams): Promise<void> {
+  const base = wpBase();
+  const auth = authHeader();
+  if (!base || !auth) return;
+
+  const res = await fetch(`${base}/wp-json/armando/v1/profile-event`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: auth },
+    body: JSON.stringify({ at: new Date().toISOString(), ...params }),
+  }).catch((err) => {
+    console.error("[logProfileEvent] fetch error:", err);
+    return null;
+  });
+
+  if (res && !res.ok) {
+    console.error(
+      "[logProfileEvent] WP error:",
+      res.status,
+      await res.text().catch(() => "")
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- **#45** — Troca o input de URL de avatar por um file picker nativo (abre galeria no mobile, explorador no desktop). Upload vai para o WP Media Library via proxy autenticado (`/api/profile/avatar`). Preview local imediato com blob URL enquanto o upload acontece.
- **#47** — Painel de usuários no WP Admin com email real visível (meta privada, sem exposição via API), colunas customizadas (avatar, email, nick, último login), metabox de histórico de atividade (login, nick_change, avatar_change com timestamps). Endpoint PHP `armando/v1/profile-event` centraliza criação de perfil, seed de avatar e audit log em uma chamada autenticada.

## Mudanças principais

| Arquivo | O que mudou |
|---|---|
| `app/api/profile/avatar/route.ts` | Novo — proxy de upload para WP Media Library |
| `app/minha-conta/ProfileForm.tsx` | File picker substitui input de URL |
| `lib/wp/profile-events.ts` | Novo utilitário `logProfileEvent()` compartilhado |
| `auth.ts` | Usa `logProfileEvent` no signIn (email + avatar seed) |
| `app/api/profile/route.ts` | Loga nick_change e avatar_change via `Promise.allSettled` |
| `blog-cms/includes/profile-events.php` | Endpoint PHP (já em produção via deploy.sh) |
| `blog-cms/includes/cpt-user-profile.php` | Meta privados + colunas WP Admin + metabox |

## Test plan

- [ ] `/minha-conta` — clicar ESCOLHER ARQUIVO, selecionar imagem, verificar preview instantâneo e upload concluído
- [ ] Salvar perfil após upload — avatar aparece nos comentários
- [ ] "usar foto do Google" ainda funciona como fallback
- [ ] WP Admin → User Profiles: colunas email, nick, avatar, último login visíveis
- [ ] Metabox de histórico: login, nick_change e avatar_change registrados
- [ ] Arquivo > 2MB ou não-imagem → erro correto