### PR TITLE
fix: displayName + avatarUrl no header e no form de comentário

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -6,7 +6,7 @@ import { logProfileEvent } from "@/lib/wp";
 
 declare module "next-auth" {
   interface Session {
-    user: { displayName: string | null } & DefaultSession["user"];
+    user: { displayName: string | null; avatarUrl: string | null } & DefaultSession["user"];
   }
 }
 
@@ -14,6 +14,7 @@ interface AppToken {
   email?: string | null;
   picture?: string | null;
   displayName?: string | null;
+  avatarUrl?: string | null;
   [key: string]: unknown;
 }
 
@@ -44,6 +45,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
 
         t.displayName = profile?.displayName ?? null;
+        t.avatarUrl = profile?.avatarUrl ?? null;
       }
 
       return t;
@@ -52,6 +54,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       const t = token as AppToken;
       if (session.user) {
         session.user.displayName = t.displayName ?? null;
+        session.user.avatarUrl = t.avatarUrl ?? null;
       }
       return session;
     },

--- a/components/content/single-post/PostCommentsSection.tsx
+++ b/components/content/single-post/PostCommentsSection.tsx
@@ -82,10 +82,10 @@ export function PostCommentsSection({ postId, initialComments }: PostCommentsSec
           {session ? (
             <>
               <div className="mb-2 flex items-center gap-2">
-                {session.user?.image && (
+                {(session.user?.avatarUrl ?? session.user?.image) && (
                   <div className="w-6 h-6 overflow-hidden border border-chrome-blue-accent flex-shrink-0">
                     <AppImage
-                      src={session.user.image}
+                      src={session.user.avatarUrl ?? session.user.image!}
                       alt={session.user.displayName ?? session.user.name ?? ""}
                       width={24}
                       height={24}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -454,17 +454,17 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
               title="Minha conta"
             >
               <div className="w-9 h-9 overflow-hidden relative flex-shrink-0 border-2 border-chrome-blue-accent">
-                {session.user.image ? (
+                {(session.user.avatarUrl ?? session.user.image) ? (
                   <Image
-                    src={session.user.image}
-                    alt={session.user.name ?? "avatar"}
+                    src={session.user.avatarUrl ?? session.user.image!}
+                    alt={session.user.displayName ?? session.user.name ?? "avatar"}
                     fill
                     sizes="36px"
                     className="object-cover"
                   />
                 ) : (
                   <div className="w-full h-full bg-chrome-blue-mid flex items-center justify-center font-mono text-chrome-blue-content" style={{ fontSize: 14 }}>
-                    {session.user.name?.[0]?.toUpperCase() ?? "?"}
+                    {(session.user.displayName ?? session.user.name)?.[0]?.toUpperCase() ?? "?"}
                   </div>
                 )}
               </div>
@@ -472,7 +472,7 @@ export function Header({ onMobileMenuToggle }: HeaderProps) {
                 className="hidden sm:block font-mono font-bold text-chrome-blue-content truncate max-w-[90px]"
                 style={{ fontSize: "11px" }}
               >
-                {session.user.name?.split(" ")[0].toUpperCase()}
+                {(session.user.displayName ?? session.user.name?.split(" ")[0])?.toUpperCase()}
               </span>
             </Link>
 


### PR DESCRIPTION
Completa o #48 — o JWT agora carrega também o `avatarUrl` do perfil WP (além do `displayName`).

**O que mudou:**
- `auth.ts`: `t.avatarUrl = profile?.avatarUrl ?? null` no jwt callback; `session.user.avatarUrl` no session callback
- `Header.tsx`: mostra `avatarUrl ?? image` e `displayName ?? name` — quem tem foto/nick customizado vê os seus dados, não os do Google
- `PostCommentsSection.tsx`: mesmo fix no mini-header do formulário de comentário