### PR TITLE
feat: auth proxy for route protection (#44)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,24 @@
+import { auth } from "@/auth";
+import { NextResponse } from "next/server";
+
+const PROTECTED = ["/minha-conta"];
+const GUEST_ONLY = ["/login"];
+
+export default auth((req) => {
+  const { nextUrl, auth: session } = req;
+  const isLoggedIn = !!session;
+
+  if (PROTECTED.some((path) => nextUrl.pathname.startsWith(path)) && !isLoggedIn) {
+    const loginUrl = new URL("/login", nextUrl);
+    loginUrl.searchParams.set("callbackUrl", nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  if (GUEST_ONLY.some((path) => nextUrl.pathname.startsWith(path)) && isLoggedIn) {
+    return NextResponse.redirect(new URL("/", nextUrl));
+  }
+});
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|api/).*)"],
+};


### PR DESCRIPTION
## Summary

- Replaces deprecated `middleware.ts` with `proxy.ts` following Next.js 16 convention (middleware renamed to proxy)
- Protects `/minha-conta` — unauthenticated users are redirected to `/login?callbackUrl=/minha-conta`
- Redirects already-logged-in users away from `/login` → `/`

## What changed from middleware.ts

Next.js 16 deprecated `middleware.ts` in favor of `proxy.ts`. The file and convention were renamed; the Auth.js `auth()` wrapper continues to work as the default export. No logic changes — only the file name changed.

## Test plan

- [ ] Log out → navigate to `/minha-conta` → should redirect to `/login?callbackUrl=%2Fminha-conta`
- [ ] Log in → navigate to `/login` → should redirect to `/`
- [ ] Logged-in user accesses `/minha-conta` → no redirect, page loads normally

Closes #44